### PR TITLE
fix(docs): broken relative links on intro page for GitHub Pages

### DIFF
--- a/docs/docs/ministry-deep-dive/intro.md
+++ b/docs/docs/ministry-deep-dive/intro.md
@@ -8,22 +8,22 @@ This section provides a structured exploration of the legislative ecosystem unde
 
 ## What's Here
 
-- **[Health Ministry Overview](./health-ministry)** — All 18 Acts assigned to the Minister of Health, organized by domain
-- **[Act Lineage](./act-lineage)** — Cross-reference network and per-act amendment histories (see table below)
-- **[Meetings Registry](./meetings)** — Searchable table of statutory body meeting requirements across all analyzed acts
-- **[Data Model Reference](./data-model)** — JSON schema documentation and OpenGIN field mapping
+- **[Health Ministry Overview](../ministry-deep-dive/health-ministry)** — All 18 Acts assigned to the Minister of Health, organized by domain
+- **[Act Lineage](../ministry-deep-dive/act-lineage)** — Cross-reference network and per-act amendment histories (see table below)
+- **[Meetings Registry](../ministry-deep-dive/meetings)** — Searchable table of statutory body meeting requirements across all analyzed acts
+- **[Data Model Reference](../ministry-deep-dive/data-model)** — JSON schema documentation and OpenGIN field mapping
 
 ### Act Deep Dives
 
 | Act / Ordinance | Lineage | Deep Dive | Key Topics |
 |-----------------|---------|-----------|------------|
-| Health Services Act | [Lineage](./act-lineage/health-services-act/lineage) | [Deep Dive](./act-lineage/health-services-act/deep-dive) | Health Council, Provincial Health Committees, amendment timeline |
-| Medical Ordinance | [Lineage](./act-lineage/medical-ordinance/lineage) | [Deep Dive](./act-lineage/medical-ordinance/deep-dive) | Sri Lanka Medical Council, medical practitioner registration |
-| Medical Wants Ordinance | [Lineage](./act-lineage/medical-wants-ordinance/lineage) | [Deep Dive](./act-lineage/medical-wants-ordinance/deep-dive) | Medical supplies regulation |
-| Mental Disease Ordinance | [Lineage](./act-lineage/mental-disease-ordinance/lineage) | [Deep Dive](./act-lineage/mental-disease-ordinance/deep-dive) | Mental health governance framework |
-| National Health Dev. Fund Act | [Lineage](./act-lineage/national-health-dev-fund/lineage) | [Deep Dive](./act-lineage/national-health-dev-fund/deep-dive) | NHDF Board of Management |
-| Nursing Homes (Regulations) Act | [Lineage](./act-lineage/nursing-homes-act/lineage) | [Deep Dive](./act-lineage/nursing-homes-act/deep-dive) | Private nursing home registration |
-| Poisons, Opium & Dangerous Drugs Ordinance | [Lineage](./act-lineage/poisons-opium-drugs/lineage) | [Deep Dive](./act-lineage/poisons-opium-drugs/deep-dive) | Controlled substances regulation |
+| Health Services Act | [Lineage](../ministry-deep-dive/act-lineage/health-services-act/lineage) | [Deep Dive](../ministry-deep-dive/act-lineage/health-services-act/deep-dive) | Health Council, Provincial Health Committees, amendment timeline |
+| Medical Ordinance | [Lineage](../ministry-deep-dive/act-lineage/medical-ordinance/lineage) | [Deep Dive](../ministry-deep-dive/act-lineage/medical-ordinance/deep-dive) | Sri Lanka Medical Council, medical practitioner registration |
+| Medical Wants Ordinance | [Lineage](../ministry-deep-dive/act-lineage/medical-wants-ordinance/lineage) | [Deep Dive](../ministry-deep-dive/act-lineage/medical-wants-ordinance/deep-dive) | Medical supplies regulation |
+| Mental Disease Ordinance | [Lineage](../ministry-deep-dive/act-lineage/mental-disease-ordinance/lineage) | [Deep Dive](../ministry-deep-dive/act-lineage/mental-disease-ordinance/deep-dive) | Mental health governance framework |
+| National Health Dev. Fund Act | [Lineage](../ministry-deep-dive/act-lineage/national-health-dev-fund/lineage) | [Deep Dive](../ministry-deep-dive/act-lineage/national-health-dev-fund/deep-dive) | NHDF Board of Management |
+| Nursing Homes (Regulations) Act | [Lineage](../ministry-deep-dive/act-lineage/nursing-homes-act/lineage) | [Deep Dive](../ministry-deep-dive/act-lineage/nursing-homes-act/deep-dive) | Private nursing home registration |
+| Poisons, Opium & Dangerous Drugs Ordinance | [Lineage](../ministry-deep-dive/act-lineage/poisons-opium-drugs/lineage) | [Deep Dive](../ministry-deep-dive/act-lineage/poisons-opium-drugs/deep-dive) | Controlled substances regulation |
 
 ## OpenGIN Entity Mapping
 


### PR DESCRIPTION
GitHub Pages serves URLs with trailing slashes (/intro/), causing ./health-ministry to resolve as /intro/health-ministry. Use absolute-style relative paths (../ministry-deep-dive/) to fix link resolution.