### PR TITLE
feat(docs): add Act Summaries section with reusable slideshow component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,12 @@ Relationships are string ID references between entities.
 - 16 pages in `docs/docs/ministry-deep-dive/` (including meetings registry)
 - 6 components: `StatusIndicator`, `MinistryOverview`, `StatutoryBodiesExplorer`, `AmendmentTimeline`, `EntityRelationshipView`, `MeetingsRegistry`
 
+### Act Summaries
+- Reusable `ActSlideshow` component with cover, content, and summary slide types
+- Telecommunications Act lineage slideshow in `docs/src/data/telecom-act-slideshow.json`
+- 1 component: `ActSlideshow` (CSS Modules, dark mode, responsive, keyboard nav, auto-play)
+- Section landing page + 1 act page in `docs/docs/act-summaries/`
+
 ### What's Next
 - Deep dive into more acts (NMRA, Nurses' Council, etc.)
 - Add more ministries using the same pattern

--- a/docs/docs/act-summaries/index.md
+++ b/docs/docs/act-summaries/index.md
@@ -1,0 +1,28 @@
+---
+title: Act Summaries
+sidebar_label: Act Summaries
+---
+
+# Act Summaries
+
+Interactive slide-based summaries of Sri Lankan legislative acts. Each summary presents the act's lineage as a visual slideshow — covering the principal act, key amendments, and a consolidated timeline.
+
+## Available Summaries
+
+| Act | Year Range | Slides |
+|-----|-----------|--------|
+| [Telecommunications Act](./telecom-act) | 1991 – 2026 | 7 |
+
+## How It Works
+
+Each summary is driven by a JSON data file and rendered by the reusable `ActSlideshow` component. To add a new act summary:
+
+1. Create a JSON file in `docs/src/data/` following the slideshow schema
+2. Create an MDX page that imports the component and data
+3. Add the page to the sidebar
+
+## Navigation
+
+- **Arrow keys** (when slideshow is focused) — move between slides
+- **Dot indicators** — jump to any slide
+- **Auto Play** — cycles through slides automatically

--- a/docs/docs/act-summaries/telecom-act.mdx
+++ b/docs/docs/act-summaries/telecom-act.mdx
@@ -1,0 +1,13 @@
+---
+title: Telecommunications Act Lineage
+sidebar_label: Telecommunications Act
+---
+
+import ActSlideshow from '@site/src/components/ActSlideshow';
+import data from '@site/src/data/telecom-act-slideshow.json';
+
+# Telecommunications Act Lineage
+
+An interactive summary of Sri Lanka's Telecommunications Act (No. 25 of 1991) and its amendments through 2026.
+
+<ActSlideshow data={data} height="620px" />

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -25,6 +25,13 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'category',
+          label: 'Act Summaries',
+          collapsible: true,
+          link: { type: 'doc', id: 'act-summaries/index' },
+          items: ['act-summaries/telecom-act'],
+        },
+        {
+          type: 'category',
           label: 'Ministry Deep Dive',
           collapsible: true,
           link: { type: 'doc', id: 'ministry-deep-dive/intro' },

--- a/docs/src/components/ActSlideshow.module.css
+++ b/docs/src/components/ActSlideshow.module.css
@@ -1,0 +1,621 @@
+/* ===== Container ===== */
+.slideshow {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+  user-select: none;
+  outline: none;
+}
+.slideshow:focus-visible {
+  box-shadow: 0 0 0 3px rgba(14, 77, 107, 0.3);
+}
+
+[data-theme='dark'] .slideshow {
+  border-color: #334155;
+  background: #1e293b;
+}
+
+/* ===== Slide layer ===== */
+.slideTrack {
+  position: relative;
+  width: 100%;
+}
+
+.slide {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 48px 80px;
+  opacity: 0;
+  transform: translateX(60px);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+  pointer-events: none;
+}
+.slideActive {
+  opacity: 1;
+  transform: translateX(0);
+  pointer-events: all;
+}
+.slideExitLeft {
+  opacity: 0;
+  transform: translateX(-60px);
+}
+
+/* ===== Cover slide ===== */
+.coverSlide {
+  background: linear-gradient(135deg, #0e4d6b 0%, #1a7ba5 50%, #0891b2 100%);
+  color: white;
+  text-align: center;
+}
+.coverSlide::before {
+  content: '';
+  position: absolute;
+  top: -100px;
+  right: -100px;
+  width: 500px;
+  height: 500px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 50%;
+  pointer-events: none;
+}
+.coverSlide::after {
+  content: '';
+  position: absolute;
+  bottom: -150px;
+  left: -80px;
+  width: 400px;
+  height: 400px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 50%;
+  pointer-events: none;
+}
+.coverLogo {
+  height: 90px;
+  background: white;
+  padding: 12px 20px;
+  border-radius: 16px;
+  margin-bottom: 40px;
+}
+.coverTitle {
+  font-size: 2.8em;
+  font-weight: 800;
+  letter-spacing: -1px;
+  margin-bottom: 12px;
+  line-height: 1.2;
+  color: white;
+}
+.coverSubtitle {
+  font-size: 1.4em;
+  font-weight: 300;
+  opacity: 0.9;
+  margin-bottom: 8px;
+}
+.coverTagline {
+  font-size: 1.05em;
+  opacity: 0.6;
+  font-weight: 300;
+}
+.coverDivider {
+  width: 80px;
+  height: 4px;
+  background: #f59e0b;
+  border-radius: 2px;
+  margin: 24px auto;
+}
+
+/* ===== Content slide ===== */
+.contentSlide {
+  background: #f8fafc;
+  align-items: flex-start;
+}
+[data-theme='dark'] .contentSlide {
+  background: #1e293b;
+}
+
+.accentBar {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 6px;
+  height: 100%;
+  border-radius: 12px 0 0 12px;
+}
+
+.slideNumber {
+  position: absolute;
+  top: 24px;
+  right: 32px;
+  font-size: 0.85em;
+  font-weight: 600;
+  color: #94a3b8;
+}
+[data-theme='dark'] .slideNumber {
+  color: #64748b;
+}
+
+.yearLabel {
+  display: inline-block;
+  background: #f59e0b;
+  color: #0e4d6b;
+  font-weight: 700;
+  padding: 6px 20px;
+  border-radius: 24px;
+  font-size: 1em;
+  margin-bottom: 16px;
+}
+
+.contentHeading {
+  font-size: 2.2em;
+  font-weight: 800;
+  color: #0e4d6b;
+  margin-bottom: 8px;
+  letter-spacing: -0.5px;
+}
+[data-theme='dark'] .contentHeading {
+  color: #7dd3fc;
+}
+
+.actLabel {
+  font-size: 1em;
+  font-weight: 600;
+  color: #1a7ba5;
+  margin-bottom: 24px;
+  display: inline-block;
+  background: #e0f2fe;
+  padding: 6px 20px;
+  border-radius: 24px;
+}
+[data-theme='dark'] .actLabel {
+  background: #0c4a6e;
+  color: #7dd3fc;
+}
+
+.itemList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+}
+.itemListItem {
+  padding: 14px 0 14px 36px;
+  position: relative;
+  font-size: 1.1em;
+  border-bottom: 1px solid #e2e8f0;
+  line-height: 1.7;
+}
+[data-theme='dark'] .itemListItem {
+  border-bottom-color: #334155;
+  color: #cbd5e1;
+}
+.itemListItem:last-child {
+  border-bottom: none;
+}
+.itemListItem::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 22px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #f59e0b;
+}
+.itemHighlight {
+  color: #0e4d6b;
+  font-weight: 700;
+}
+[data-theme='dark'] .itemHighlight {
+  color: #7dd3fc;
+}
+
+.sourceLink {
+  display: inline-block;
+  margin-top: 20px;
+  font-size: 0.85em;
+  color: #94a3b8;
+  text-decoration: none;
+}
+.sourceLink:hover {
+  color: #64748b;
+  text-decoration: underline;
+}
+
+.noteText {
+  margin-top: 16px;
+  font-size: 0.95em;
+  color: #f59e0b;
+  font-weight: 600;
+}
+
+/* Amendment flex (side logo) */
+.amendmentFlex {
+  display: flex;
+  align-items: center;
+  gap: 40px;
+  width: 100%;
+}
+.amendmentFlexContent {
+  flex: 1;
+}
+.amendmentFlexLogo {
+  flex-shrink: 0;
+  text-align: center;
+}
+.amendmentFlexLogoImg {
+  width: 140px;
+  background: white;
+  padding: 16px;
+  border-radius: 16px;
+  border: 2px solid #e2e8f0;
+}
+[data-theme='dark'] .amendmentFlexLogoImg {
+  border-color: #334155;
+}
+
+/* Alert variant */
+.alertSlide {
+  background: linear-gradient(160deg, #fef2f2 0%, #fff7ed 100%);
+}
+[data-theme='dark'] .alertSlide {
+  background: linear-gradient(160deg, #450a0a 0%, #431407 100%);
+}
+.alertSlide .contentHeading {
+  color: #dc2626;
+}
+[data-theme='dark'] .alertSlide .contentHeading {
+  color: #fca5a5;
+}
+.alertSlide .actLabel {
+  background: #fee2e2;
+  color: #dc2626;
+}
+[data-theme='dark'] .alertSlide .actLabel {
+  background: #7f1d1d;
+  color: #fca5a5;
+}
+.alertSlide .yearLabel {
+  background: #fee2e2;
+  color: #dc2626;
+}
+.alertItem {
+  padding: 12px 0;
+  font-size: 1.1em;
+  border-bottom: 1px solid #fecaca;
+  line-height: 1.7;
+  width: 100%;
+}
+[data-theme='dark'] .alertItem {
+  border-bottom-color: #7f1d1d;
+  color: #cbd5e1;
+}
+.alertItem:last-of-type {
+  border-bottom: none;
+}
+.alertItemStrong {
+  color: #dc2626;
+  font-weight: 700;
+}
+[data-theme='dark'] .alertItemStrong {
+  color: #fca5a5;
+}
+
+/* ===== Summary slide ===== */
+.summarySlide {
+  align-items: flex-start;
+  background: #f8fafc;
+}
+[data-theme='dark'] .summarySlide {
+  background: #1e293b;
+}
+
+.summaryHeading {
+  font-size: 2.2em;
+  font-weight: 800;
+  color: #0e4d6b;
+  margin-bottom: 16px;
+}
+[data-theme='dark'] .summaryHeading {
+  color: #7dd3fc;
+}
+
+.summaryTable {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-top: 12px;
+  font-size: 1.05em;
+}
+.summaryTable thead th {
+  background: #0e4d6b;
+  color: white;
+  padding: 14px 24px;
+  text-align: left;
+  font-weight: 700;
+}
+.summaryTable thead th:first-child {
+  border-radius: 12px 0 0 0;
+}
+.summaryTable thead th:last-child {
+  border-radius: 0 12px 0 0;
+}
+.summaryTable tbody td {
+  padding: 14px 24px;
+  border-bottom: 1px solid #e2e8f0;
+}
+[data-theme='dark'] .summaryTable tbody td {
+  border-bottom-color: #334155;
+  color: #cbd5e1;
+}
+.summaryTable tbody tr:nth-child(even) {
+  background: #f1f5f9;
+}
+[data-theme='dark'] .summaryTable tbody tr:nth-child(even) {
+  background: #0f172a;
+}
+.summaryTable tbody tr:last-child td:first-child {
+  border-radius: 0 0 0 12px;
+}
+.summaryTable tbody tr:last-child td:last-child {
+  border-radius: 0 0 12px 0;
+}
+
+.yearBadge {
+  display: inline-block;
+  background: #1a7ba5;
+  color: white;
+  padding: 4px 14px;
+  border-radius: 14px;
+  font-weight: 700;
+  font-size: 0.9em;
+}
+
+.footerText {
+  position: absolute;
+  bottom: 24px;
+  left: 0;
+  width: 100%;
+  text-align: center;
+  color: #94a3b8;
+  font-size: 0.85em;
+}
+
+/* ===== Navigation ===== */
+.navArrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(14, 77, 107, 0.85);
+  color: white;
+  font-size: 1.2em;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s, transform 0.2s, opacity 0.3s;
+  backdrop-filter: blur(4px);
+}
+.navArrow:hover {
+  background: rgba(14, 77, 107, 1);
+  transform: translateY(-50%) scale(1.1);
+}
+.navArrow:active {
+  transform: translateY(-50%) scale(0.95);
+}
+.navArrowHidden {
+  opacity: 0;
+  pointer-events: none;
+}
+.navPrev {
+  left: 16px;
+}
+.navNext {
+  right: 16px;
+}
+
+/* Cover-specific nav overrides */
+.onCover .navArrow {
+  background: rgba(255, 255, 255, 0.25);
+}
+.onCover .navArrow:hover {
+  background: rgba(255, 255, 255, 0.5);
+}
+
+/* ===== Bottom bar ===== */
+.bottomBar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 20px;
+  gap: 16px;
+  position: relative;
+  border-top: 1px solid #e2e8f0;
+  background: white;
+  border-radius: 0 0 12px 12px;
+}
+[data-theme='dark'] .bottomBar {
+  border-top-color: #334155;
+  background: #0f172a;
+}
+
+/* Cover-specific bottom bar */
+.onCover .bottomBar {
+  background: #0a3d55;
+  border-top-color: rgba(255, 255, 255, 0.1);
+}
+
+.dots {
+  display: flex;
+  gap: 8px;
+}
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #cbd5e1;
+  cursor: pointer;
+  transition: background 0.3s, transform 0.3s;
+  border: none;
+  padding: 0;
+}
+.dot:hover {
+  background: #1a7ba5;
+}
+.dotActive {
+  background: #0e4d6b;
+  transform: scale(1.3);
+}
+[data-theme='dark'] .dot {
+  background: #475569;
+}
+[data-theme='dark'] .dotActive {
+  background: #7dd3fc;
+}
+
+/* Cover dot overrides */
+.onCover .dot {
+  background: rgba(255, 255, 255, 0.35);
+}
+.onCover .dotActive {
+  background: white;
+}
+
+.btnAuto {
+  padding: 4px 14px;
+  border-radius: 20px;
+  border: 2px solid #0e4d6b;
+  background: transparent;
+  color: #0e4d6b;
+  font-size: 0.78em;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  position: absolute;
+  right: 16px;
+}
+.btnAuto:hover {
+  background: #0e4d6b;
+  color: white;
+}
+.btnAutoPlaying {
+  background: #0e4d6b;
+  color: white;
+}
+[data-theme='dark'] .btnAuto {
+  border-color: #7dd3fc;
+  color: #7dd3fc;
+}
+[data-theme='dark'] .btnAuto:hover {
+  background: #7dd3fc;
+  color: #0f172a;
+}
+[data-theme='dark'] .btnAutoPlaying {
+  background: #7dd3fc;
+  color: #0f172a;
+}
+
+/* Cover auto-play overrides */
+.onCover .btnAuto {
+  border-color: white;
+  color: white;
+}
+.onCover .btnAuto:hover {
+  background: rgba(255, 255, 255, 0.25);
+  color: white;
+}
+.onCover .btnAutoPlaying {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.keyHint {
+  position: absolute;
+  left: 16px;
+  font-size: 0.72em;
+  color: #94a3b8;
+}
+.keyHintKbd {
+  background: #e2e8f0;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 0.95em;
+}
+[data-theme='dark'] .keyHintKbd {
+  background: #334155;
+  color: #cbd5e1;
+}
+.onCover .keyHint {
+  color: rgba(255, 255, 255, 0.4);
+}
+.onCover .keyHintKbd {
+  background: rgba(255, 255, 255, 0.15);
+  color: white;
+}
+
+/* ===== Progress bar ===== */
+.progressBar {
+  height: 4px;
+  background: #f59e0b;
+  transition: width 0.5s ease;
+}
+.onCover .progressBar {
+  background: rgba(255, 255, 255, 0.5);
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 768px) {
+  .slide {
+    padding: 32px 24px;
+  }
+  .coverTitle {
+    font-size: 1.8em;
+  }
+  .coverSubtitle {
+    font-size: 1.1em;
+  }
+  .contentHeading,
+  .summaryHeading {
+    font-size: 1.6em;
+  }
+  .amendmentFlex {
+    flex-direction: column;
+    gap: 20px;
+  }
+  .amendmentFlexLogo {
+    display: none;
+  }
+  .navArrow {
+    width: 36px;
+    height: 36px;
+    font-size: 1em;
+  }
+  .navPrev {
+    left: 8px;
+  }
+  .navNext {
+    right: 8px;
+  }
+  .summaryTable {
+    font-size: 0.85em;
+  }
+  .summaryTable thead th,
+  .summaryTable tbody td {
+    padding: 10px 12px;
+  }
+  .keyHint {
+    display: none;
+  }
+}

--- a/docs/src/components/ActSlideshow.tsx
+++ b/docs/src/components/ActSlideshow.tsx
@@ -1,0 +1,364 @@
+import { useState, useEffect, useCallback, useRef, type ReactNode } from 'react';
+import styles from './ActSlideshow.module.css';
+
+/* ===== Data types ===== */
+
+interface SlideshowMeta {
+  actId: string;
+  title: string;
+  subtitle: string;
+  tagline: string;
+  logoUrl: string;
+  logoAlt: string;
+}
+
+interface CoverSlide {
+  type: 'cover';
+}
+
+interface ContentItem {
+  highlight: string;
+  text: string;
+}
+
+interface ContentSlide {
+  type: 'content';
+  year: number;
+  heading: string;
+  actLabel: string;
+  accentColor: string;
+  items: ContentItem[];
+  sourceUrl?: string;
+  sourceLabel?: string;
+  sideLogoUrl?: string;
+  sideLogoAlt?: string;
+  note?: string;
+  variant?: 'default' | 'alert';
+}
+
+interface SummaryRow {
+  cells: string[];
+  yearBadge?: boolean;
+}
+
+interface SummarySlide {
+  type: 'summary';
+  heading: string;
+  accentColor: string;
+  columns: string[];
+  rows: SummaryRow[];
+  footer?: string;
+}
+
+type Slide = CoverSlide | ContentSlide | SummarySlide;
+
+export interface SlideshowData {
+  meta: SlideshowMeta;
+  slides: Slide[];
+}
+
+interface ActSlideshowProps {
+  data: SlideshowData;
+  height?: string;
+  autoPlayInterval?: number;
+}
+
+/* ===== Sub-components ===== */
+
+function CoverSlideView({ meta }: { meta: SlideshowMeta }) {
+  return (
+    <div className={styles.coverSlide} style={{ width: '100%', height: '100%' }}>
+      <img className={styles.coverLogo} src={meta.logoUrl} alt={meta.logoAlt} />
+      <h1 className={styles.coverTitle}>{meta.title}</h1>
+      <div className={styles.coverDivider} />
+      <p className={styles.coverSubtitle}>{meta.subtitle}</p>
+      <p className={styles.coverTagline}>{meta.tagline}</p>
+    </div>
+  );
+}
+
+function ContentSlideView({
+  slide,
+  slideNumber,
+  totalContent,
+}: {
+  slide: ContentSlide;
+  slideNumber: number;
+  totalContent: number;
+}) {
+  const isAlert = slide.variant === 'alert';
+
+  const listContent = (
+    <ul className={styles.itemList}>
+      {slide.items.map((item, i) =>
+        isAlert ? (
+          <div key={i} className={styles.alertItem}>
+            <span className={styles.alertItemStrong}>{item.highlight}</span> {item.text}
+          </div>
+        ) : (
+          <li key={i} className={styles.itemListItem}>
+            <span className={styles.itemHighlight}>{item.highlight}</span> {item.text}
+          </li>
+        ),
+      )}
+    </ul>
+  );
+
+  return (
+    <div
+      className={`${styles.contentSlide} ${isAlert ? styles.alertSlide : ''}`}
+      style={{ width: '100%', height: '100%' }}
+    >
+      <div className={styles.accentBar} style={{ background: slide.accentColor }} />
+      <span className={styles.slideNumber}>
+        {String(slideNumber).padStart(2, '0')} / {String(totalContent).padStart(2, '0')}
+      </span>
+      <span className={styles.yearLabel}>{slide.year}</span>
+      <h2 className={styles.contentHeading}>{slide.heading}</h2>
+      <span className={styles.actLabel}>{slide.actLabel}</span>
+
+      {slide.sideLogoUrl ? (
+        <div className={styles.amendmentFlex}>
+          <div className={styles.amendmentFlexContent}>{listContent}</div>
+          <div className={styles.amendmentFlexLogo}>
+            <img
+              className={styles.amendmentFlexLogoImg}
+              src={slide.sideLogoUrl}
+              alt={slide.sideLogoAlt || ''}
+            />
+          </div>
+        </div>
+      ) : (
+        listContent
+      )}
+
+      {slide.note && <p className={styles.noteText}>{slide.note}</p>}
+      {slide.sourceUrl && (
+        <a
+          className={styles.sourceLink}
+          href={slide.sourceUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {slide.sourceLabel || slide.sourceUrl}
+        </a>
+      )}
+    </div>
+  );
+}
+
+function SummarySlideView({ slide, slideNumber, totalContent }: { slide: SummarySlide; slideNumber: number; totalContent: number }) {
+  return (
+    <div className={styles.summarySlide} style={{ width: '100%', height: '100%' }}>
+      <div className={styles.accentBar} style={{ background: slide.accentColor }} />
+      <span className={styles.slideNumber}>
+        {String(slideNumber).padStart(2, '0')} / {String(totalContent).padStart(2, '0')}
+      </span>
+      <h2 className={styles.summaryHeading}>{slide.heading}</h2>
+      <table className={styles.summaryTable}>
+        <thead>
+          <tr>
+            {slide.columns.map((col, i) => (
+              <th key={i}>{col}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {slide.rows.map((row, ri) => (
+            <tr key={ri}>
+              {row.cells.map((cell, ci) => (
+                <td key={ci}>
+                  {ci === 0 && row.yearBadge ? (
+                    <span className={styles.yearBadge}>{cell}</span>
+                  ) : (
+                    cell
+                  )}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {slide.footer && <div className={styles.footerText}>{slide.footer}</div>}
+    </div>
+  );
+}
+
+/* ===== Main component ===== */
+
+export default function ActSlideshow({
+  data,
+  height = '600px',
+  autoPlayInterval = 6000,
+}: ActSlideshowProps): ReactNode {
+  const [current, setCurrent] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const total = data.slides.length;
+  const totalContent = total - 1; // exclude cover for numbering
+  const isCover = current === 0;
+
+  const goTo = useCallback(
+    (index: number) => {
+      if (index >= 0 && index < total) setCurrent(index);
+    },
+    [total],
+  );
+
+  const next = useCallback(() => {
+    if (current < total - 1) setCurrent((c) => c + 1);
+    else setIsPlaying(false);
+  }, [current, total]);
+
+  const prev = useCallback(() => {
+    if (current > 0) setCurrent((c) => c - 1);
+  }, [current]);
+
+  const toggleAutoPlay = useCallback(() => {
+    setIsPlaying((p) => {
+      if (!p && current === total - 1) setCurrent(0);
+      return !p;
+    });
+  }, [current, total]);
+
+  // Auto-play timer
+  useEffect(() => {
+    if (isPlaying) {
+      timerRef.current = setInterval(() => {
+        setCurrent((c) => {
+          if (c < total - 1) return c + 1;
+          setIsPlaying(false);
+          return c;
+        });
+      }, autoPlayInterval);
+    }
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [isPlaying, autoPlayInterval, total]);
+
+  // Focus-scoped keyboard navigation
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'ArrowRight' || e.key === ' ') {
+        e.preventDefault();
+        next();
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        prev();
+      } else if (e.key === 'Escape') {
+        setIsPlaying(false);
+      }
+    },
+    [next, prev],
+  );
+
+  // Render a single slide
+  function renderSlide(slide: Slide, index: number) {
+    let contentIndex = index; // 1-based for content slides (cover is 0)
+    switch (slide.type) {
+      case 'cover':
+        return <CoverSlideView meta={data.meta} />;
+      case 'content':
+        return (
+          <ContentSlideView
+            slide={slide}
+            slideNumber={contentIndex}
+            totalContent={totalContent}
+          />
+        );
+      case 'summary':
+        return (
+          <SummarySlideView
+            slide={slide}
+            slideNumber={contentIndex}
+            totalContent={totalContent}
+          />
+        );
+    }
+  }
+
+  const progressWidth = total > 1 ? (current / (total - 1)) * 100 : 0;
+
+  return (
+    <div
+      ref={containerRef}
+      className={`${styles.slideshow} ${isCover ? styles.onCover : ''}`}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      role="region"
+      aria-label={`Slideshow: ${data.meta.title}`}
+      aria-roledescription="slideshow"
+    >
+      {/* Slides */}
+      <div className={styles.slideTrack} style={{ height }}>
+        {data.slides.map((slide, i) => {
+          let slideClass = styles.slide;
+          if (i === current) slideClass += ` ${styles.slideActive}`;
+          else if (i < current) slideClass += ` ${styles.slideExitLeft}`;
+          return (
+            <div
+              key={i}
+              className={slideClass}
+              role="tabpanel"
+              aria-hidden={i !== current}
+              aria-label={`Slide ${i + 1} of ${total}`}
+            >
+              {renderSlide(slide, i)}
+            </div>
+          );
+        })}
+
+        {/* Navigation arrows */}
+        <button
+          className={`${styles.navArrow} ${styles.navPrev} ${current === 0 ? styles.navArrowHidden : ''}`}
+          onClick={prev}
+          aria-label="Previous slide"
+        >
+          &#9664;
+        </button>
+        <button
+          className={`${styles.navArrow} ${styles.navNext} ${current === total - 1 ? styles.navArrowHidden : ''}`}
+          onClick={next}
+          aria-label="Next slide"
+        >
+          &#9654;
+        </button>
+      </div>
+
+      {/* Progress bar */}
+      <div className={styles.progressBar} style={{ width: `${progressWidth}%` }} />
+
+      {/* Bottom bar */}
+      <div className={styles.bottomBar}>
+        <div className={styles.keyHint}>
+          <kbd className={styles.keyHintKbd}>&larr;</kbd>{' '}
+          <kbd className={styles.keyHintKbd}>&rarr;</kbd> to navigate
+        </div>
+
+        <div className={styles.dots} role="tablist" aria-label="Slide navigation">
+          {data.slides.map((_, i) => (
+            <button
+              key={i}
+              className={`${styles.dot} ${i === current ? styles.dotActive : ''}`}
+              onClick={() => goTo(i)}
+              role="tab"
+              aria-selected={i === current}
+              aria-label={`Go to slide ${i + 1}`}
+            />
+          ))}
+        </div>
+
+        <button
+          className={`${styles.btnAuto} ${isPlaying ? styles.btnAutoPlaying : ''}`}
+          onClick={toggleAutoPlay}
+          aria-label={isPlaying ? 'Pause auto-play' : 'Start auto-play'}
+        >
+          {isPlaying ? 'Pause' : 'Auto Play'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/docs/src/data/telecom-act-slideshow.json
+++ b/docs/src/data/telecom-act-slideshow.json
@@ -1,0 +1,147 @@
+{
+  "meta": {
+    "actId": "telecom-act-25-1991",
+    "title": "Telecommunications Act Lineage",
+    "subtitle": "Sri Lanka | 1991 \u2013 2026",
+    "tagline": "A Comprehensive Regulatory Overview",
+    "logoUrl": "https://www.trc.gov.lk/images/trc-logo.png",
+    "logoAlt": "TRCSL Logo"
+  },
+  "slides": [
+    {
+      "type": "cover"
+    },
+    {
+      "type": "content",
+      "year": 1991,
+      "heading": "The Principal Act",
+      "actLabel": "Act No. 25 of 1991",
+      "accentColor": "#0E4D6B",
+      "items": [
+        {
+          "highlight": "Corporatization:",
+          "text": "Shifted from Government Department to Sri Lanka Telecom."
+        },
+        {
+          "highlight": "Licensing:",
+          "text": "Section 17 made it illegal to operate without a Ministerial license."
+        },
+        {
+          "highlight": "Authority:",
+          "text": "Created the office of the Director-General."
+        }
+      ],
+      "sourceUrl": "https://www.trc.gov.lk/images/pdf/act25_1991.pdf",
+      "sourceLabel": "Source: Act No. 25 of 1991 PDF"
+    },
+    {
+      "type": "content",
+      "year": 1996,
+      "heading": "The 1996 Amendment",
+      "actLabel": "Amendment Act No. 27 of 1996",
+      "accentColor": "#059669",
+      "items": [
+        {
+          "highlight": "TRCSL:",
+          "text": "Established as a multi-member commission."
+        },
+        {
+          "highlight": "Cess (Levy):",
+          "text": "Introduced to ensure regulatory financial independence."
+        },
+        {
+          "highlight": "Public Hearings:",
+          "text": "Mandated for transparency."
+        }
+      ],
+      "sideLogoUrl": "https://www.trc.gov.lk/images/trc-logo.png",
+      "sideLogoAlt": "TRCSL Logo",
+      "sourceUrl": "https://www.trc.gov.lk/images/pdf/act27_1996.pdf",
+      "sourceLabel": "Source: Amendment No. 27 of 1996"
+    },
+    {
+      "type": "content",
+      "year": 2019,
+      "heading": "SIM Card Regulations",
+      "actLabel": "Gazette No. 2132/65",
+      "accentColor": "#7C3AED",
+      "items": [
+        {
+          "highlight": "NIC/Passport verification:",
+          "text": "Mandatory for all new users."
+        },
+        {
+          "highlight": "Address proof:",
+          "text": "Requirement for utility bills."
+        },
+        {
+          "highlight": "Database entry:",
+          "text": "Activation only after database entry."
+        }
+      ],
+      "note": "Note: Currently applies to SIMs issued after Aug 2, 2019.",
+      "sourceUrl": "https://www.trc.gov.lk/content/files/gazette/SIM_Gazette_E.pdf",
+      "sourceLabel": "Source: 2019 Gazette PDF"
+    },
+    {
+      "type": "content",
+      "year": 2024,
+      "heading": "Modern Modernization",
+      "actLabel": "Amendment Act No. 39 of 2024",
+      "accentColor": "#0891B2",
+      "items": [
+        {
+          "highlight": "Anti-Monopoly:",
+          "text": "Regulation of Significant Market Power (SMP)."
+        },
+        {
+          "highlight": "Infrastructure Sharing:",
+          "text": "Third-party tower construction allowed."
+        },
+        {
+          "highlight": "Tariff Fairplay:",
+          "text": "Mandated cost-based, non-discriminatory pricing."
+        }
+      ],
+      "sourceUrl": "https://www.trc.gov.lk/content/files/acts/39-2024_E.pdf",
+      "sourceLabel": "Source: Amendment No. 39 of 2024"
+    },
+    {
+      "type": "content",
+      "year": 2026,
+      "heading": "The 2026 Cabinet Proposal",
+      "actLabel": "Closing the \"Legacy Gap\"",
+      "accentColor": "#DC2626",
+      "variant": "alert",
+      "items": [
+        {
+          "highlight": "Mandatory Re-registration:",
+          "text": "All SIMs obtained before Aug 2, 2019 must be re-verified."
+        },
+        {
+          "highlight": "Minors:",
+          "text": "New rules for ages 16\u201317."
+        },
+        {
+          "highlight": "Foreigners:",
+          "text": "Stricter tracking for tourist connections."
+        }
+      ],
+      "sourceUrl": "https://www.ft.lk/front-page/Govt-to-amend-SIM-card-registration-rules/44-788156",
+      "sourceLabel": "Reference: Daily FT (Feb 2026)"
+    },
+    {
+      "type": "summary",
+      "heading": "Summary of Lineage",
+      "accentColor": "#F59E0B",
+      "columns": ["Year", "Focus", "Key Impact"],
+      "rows": [
+        { "cells": ["1991", "Corporatization", "End of State Monopoly"], "yearBadge": true },
+        { "cells": ["1996", "Governance", "Creation of TRCSL"], "yearBadge": true },
+        { "cells": ["2019", "Security", "Identity Verification"], "yearBadge": true },
+        { "cells": ["2024", "Competition", "Market Fairness & 5G"], "yearBadge": true }
+      ],
+      "footer": "Prepared for Documentation Purposes \u2022 Telecommunications Regulatory Commission of Sri Lanka"
+    }
+  ]
+}


### PR DESCRIPTION
Add a new Docusaurus section for interactive slide-based act summaries. Includes the ActSlideshow React component (CSS Modules, dark mode, keyboard nav, auto-play) and the Telecommunications Act lineage as the first slideshow entry.