### PR TITLE
feat(slideshow): full-width mode to fill viewport without sidebar

### DIFF
--- a/docs/docs/act-summaries/telecom-act.mdx
+++ b/docs/docs/act-summaries/telecom-act.mdx
@@ -1,6 +1,7 @@
 ---
 title: Telecommunications Act Lineage
 sidebar_label: Telecommunications Act
+hide_table_of_contents: true
 ---
 
 import ActSlideshow from '@site/src/components/ActSlideshow';
@@ -8,6 +9,4 @@ import data from '@site/src/data/telecom-act-slideshow.json';
 
 # Telecommunications Act Lineage
 
-An interactive summary of Sri Lanka's Telecommunications Act (No. 25 of 1991) and its amendments through 2026.
-
-<ActSlideshow data={data} height="620px" />
+<ActSlideshow data={data} height="calc(100vh - 120px)" fullWidth />

--- a/docs/src/components/ActSlideshow.module.css
+++ b/docs/src/components/ActSlideshow.module.css
@@ -12,6 +12,10 @@
 .slideshow:focus-visible {
   box-shadow: 0 0 0 3px rgba(14, 77, 107, 0.3);
 }
+.fullWidth {
+  border-radius: 0;
+  border: none;
+}
 
 [data-theme='dark'] .slideshow {
   border-color: #334155;

--- a/docs/src/components/ActSlideshow.tsx
+++ b/docs/src/components/ActSlideshow.tsx
@@ -61,6 +61,7 @@ interface ActSlideshowProps {
   data: SlideshowData;
   height?: string;
   autoPlayInterval?: number;
+  fullWidth?: boolean;
 }
 
 /* ===== Sub-components ===== */
@@ -190,11 +191,21 @@ export default function ActSlideshow({
   data,
   height = '600px',
   autoPlayInterval = 6000,
+  fullWidth = false,
 }: ActSlideshowProps): ReactNode {
   const [current, setCurrent] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Full-width mode: hide sidebar and expand content
+  useEffect(() => {
+    if (!fullWidth) return;
+    document.documentElement.classList.add('slideshow-fullwidth');
+    return () => {
+      document.documentElement.classList.remove('slideshow-fullwidth');
+    };
+  }, [fullWidth]);
 
   const total = data.slides.length;
   const totalContent = total - 1; // exclude cover for numbering
@@ -285,7 +296,7 @@ export default function ActSlideshow({
   return (
     <div
       ref={containerRef}
-      className={`${styles.slideshow} ${isCover ? styles.onCover : ''}`}
+      className={`${styles.slideshow} ${isCover ? styles.onCover : ''} ${fullWidth ? styles.fullWidth : ''}`}
       tabIndex={0}
       onKeyDown={handleKeyDown}
       role="region"

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -97,3 +97,49 @@
   color: var(--ifm-color-primary);
   margin-bottom: 4px;
 }
+
+/* ===== Slideshow full-width mode ===== */
+html.slideshow-fullwidth .docSidebarContainer,
+html.slideshow-fullwidth aside[class*='docSidebar'] {
+  display: none !important;
+}
+
+html.slideshow-fullwidth .docMainContainer {
+  max-width: 100% !important;
+  width: 100% !important;
+}
+
+html.slideshow-fullwidth main > .container {
+  max-width: 100% !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+html.slideshow-fullwidth main > .container > .row {
+  margin: 0 !important;
+}
+
+html.slideshow-fullwidth main > .container > .row > .col {
+  max-width: 100% !important;
+  padding: 0 16px !important;
+}
+
+html.slideshow-fullwidth article > header {
+  display: none;
+}
+
+html.slideshow-fullwidth .table-of-contents {
+  display: none !important;
+}
+
+html.slideshow-fullwidth .pagination-nav {
+  display: none;
+}
+
+html.slideshow-fullwidth .theme-doc-breadcrumbs {
+  display: none;
+}
+
+html.slideshow-fullwidth .theme-doc-markdown > h1:first-child {
+  display: none;
+}


### PR DESCRIPTION
Add fullWidth prop that hides the Docusaurus sidebar, breadcrumbs, and pagination, expanding the slideshow to use the full page width and viewport height for a presentation-like experience.