### PR TITLE
feat: add Act Anatomy Explorer with radar charts and dark mode

### DIFF
--- a/docs/docs/act-explorer/index.mdx
+++ b/docs/docs/act-explorer/index.mdx
@@ -1,0 +1,12 @@
+---
+title: Act Explorer
+sidebar_label: Act Explorer
+---
+
+import ActAnatomyExplorer from '@site/src/components/ActAnatomyExplorer';
+
+# Act Anatomy Explorer
+
+Interactive visualization of the internal anatomy of **18 Sri Lankan legislative acts** under the Ministry of Health. Select any act to explore its functional profile, statutory bodies, amendment timeline, governance hierarchy, and data confidence.
+
+<ActAnatomyExplorer />

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -15,7 +15,8 @@
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "recharts": "^3.7.0"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.9.2",
@@ -4774,6 +4775,42 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -4828,6 +4865,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
@@ -5720,6 +5763,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -8448,6 +8497,12 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
@@ -8937,6 +8992,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esast-util-from-estree": {
       "version": "2.0.0",
@@ -10595,6 +10660,16 @@
       },
       "engines": {
         "node": ">=16.x"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -16448,6 +16523,29 @@
         "webpack": ">=4.41.1 || 5.x"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-router": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
@@ -16525,6 +16623,42 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
+      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/recma-build-jsx": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
@@ -16590,6 +16724,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect-metadata": {
@@ -16975,6 +17124,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -18869,6 +19024,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vscode-jsonrpc": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,7 +22,8 @@
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "recharts": "^3.7.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.9.2",

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -31,6 +31,11 @@ const sidebars: SidebarsConfig = {
           items: ['act-summaries/telecom-act'],
         },
         {
+          type: 'doc',
+          id: 'act-explorer/index',
+          label: 'Act Explorer',
+        },
+        {
           type: 'category',
           label: 'Ministry Deep Dive',
           collapsible: true,

--- a/docs/src/components/ActAnatomyExplorer.module.css
+++ b/docs/src/components/ActAnatomyExplorer.module.css
@@ -1,0 +1,624 @@
+/* ===== Container ===== */
+.explorer {
+  max-width: 100%;
+}
+
+/* ===== Selector Bar ===== */
+.selectorBar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.actSelect {
+  flex: 1;
+  min-width: 240px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  background: white;
+  font-size: 0.95em;
+  color: #1e293b;
+  cursor: pointer;
+}
+[data-theme='dark'] .actSelect {
+  background: #1e293b;
+  border-color: #334155;
+  color: #e2e4e8;
+}
+
+.domainBadge {
+  display: inline-block;
+  padding: 4px 14px;
+  border-radius: 20px;
+  font-size: 0.8em;
+  font-weight: 600;
+  color: white;
+  white-space: nowrap;
+}
+
+.kindBadge {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-size: 0.78em;
+  font-weight: 600;
+  background: #e2e8f0;
+  color: #475569;
+}
+[data-theme='dark'] .kindBadge {
+  background: #334155;
+  color: #94a3b8;
+}
+
+/* ===== Hero Panel ===== */
+.heroPanel {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 24px;
+  margin-bottom: 20px;
+}
+[data-theme='dark'] .heroPanel {
+  background: #1e293b;
+  border-color: #334155;
+}
+
+.heroTitle {
+  font-size: 1.5em;
+  font-weight: 700;
+  margin: 0 0 4px 0;
+  color: #0f172a;
+}
+[data-theme='dark'] .heroTitle {
+  color: #f1f5f9;
+}
+
+.heroMeta {
+  font-size: 0.9em;
+  color: #64748b;
+  margin-bottom: 16px;
+}
+[data-theme='dark'] .heroMeta {
+  color: #94a3b8;
+}
+
+.repealedWarning {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  padding: 10px 14px;
+  margin-bottom: 16px;
+  font-size: 0.9em;
+  color: #991b1b;
+}
+[data-theme='dark'] .repealedWarning {
+  background: #450a0a;
+  border-color: #7f1d1d;
+  color: #fca5a5;
+}
+
+.statCards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.statCard {
+  text-align: center;
+  padding: 12px 8px;
+  background: #f8fafc;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+}
+[data-theme='dark'] .statCard {
+  background: #0f172a;
+  border-color: #334155;
+}
+
+.statValue {
+  font-size: 1.6em;
+  font-weight: 700;
+  color: #0e4d6b;
+  line-height: 1.2;
+}
+[data-theme='dark'] .statValue {
+  color: #7dd3fc;
+}
+
+.statLabel {
+  font-size: 0.75em;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-top: 2px;
+}
+[data-theme='dark'] .statLabel {
+  color: #94a3b8;
+}
+
+.heroSummary {
+  font-size: 0.95em;
+  color: #475569;
+  line-height: 1.6;
+  margin: 0;
+}
+[data-theme='dark'] .heroSummary {
+  color: #cbd5e1;
+}
+
+.pdfLink {
+  display: inline-block;
+  margin-top: 10px;
+  font-size: 0.85em;
+  color: #2563eb;
+  text-decoration: none;
+}
+.pdfLink:hover {
+  text-decoration: underline;
+}
+[data-theme='dark'] .pdfLink {
+  color: #60a5fa;
+}
+
+/* ===== Tab Bar ===== */
+.tabBar {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+/* ===== Overview Tab: Two-Column ===== */
+.overviewGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+
+.overviewLeft,
+.overviewRight {
+  min-width: 0;
+}
+
+/* ===== Radar Chart ===== */
+.radarContainer {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 20px;
+}
+[data-theme='dark'] .radarContainer {
+  background: #1e293b;
+  border-color: #334155;
+}
+
+.radarPlaceholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 300px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  color: #94a3b8;
+  font-size: 0.9em;
+}
+[data-theme='dark'] .radarPlaceholder {
+  background: #0f172a;
+  border-color: #334155;
+  color: #64748b;
+}
+
+/* ===== Confidence Panel ===== */
+.confidencePanel {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 20px;
+  margin-bottom: 16px;
+}
+[data-theme='dark'] .confidencePanel {
+  background: #1e293b;
+  border-color: #334155;
+}
+
+.confidenceTitle {
+  font-size: 0.9em;
+  font-weight: 600;
+  color: #0f172a;
+  margin: 0 0 12px 0;
+}
+[data-theme='dark'] .confidenceTitle {
+  color: #f1f5f9;
+}
+
+.confidenceRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: 0.88em;
+}
+
+.confidenceDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.confidenceLabel {
+  color: #475569;
+}
+[data-theme='dark'] .confidenceLabel {
+  color: #94a3b8;
+}
+
+/* ===== Cross-References ===== */
+.crossRefPanel {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 20px;
+}
+[data-theme='dark'] .crossRefPanel {
+  background: #1e293b;
+  border-color: #334155;
+}
+
+.crossRefTitle {
+  font-size: 0.9em;
+  font-weight: 600;
+  color: #0f172a;
+  margin: 0 0 12px 0;
+}
+[data-theme='dark'] .crossRefTitle {
+  color: #f1f5f9;
+}
+
+.crossRefBadges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.crossRefBadge {
+  padding: 6px 14px;
+  border-radius: 20px;
+  font-size: 0.82em;
+  font-weight: 500;
+  background: #e0f2fe;
+  color: #0369a1;
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.1s;
+}
+.crossRefBadge:hover {
+  background: #bae6fd;
+  transform: scale(1.03);
+}
+[data-theme='dark'] .crossRefBadge {
+  background: #0c4a6e;
+  color: #7dd3fc;
+}
+[data-theme='dark'] .crossRefBadge:hover {
+  background: #075985;
+}
+
+/* ===== Body Cards ===== */
+.bodyCard {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 16px 20px;
+  margin-bottom: 12px;
+  border-left: 4px solid;
+}
+[data-theme='dark'] .bodyCard {
+  background: #1e293b;
+  border-color: #334155;
+}
+
+.bodyHeader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.bodyName {
+  font-weight: 600;
+  font-size: 1em;
+  color: #0f172a;
+}
+[data-theme='dark'] .bodyName {
+  color: #f1f5f9;
+}
+
+.bodySections {
+  font-size: 0.82em;
+  color: #64748b;
+}
+[data-theme='dark'] .bodySections {
+  color: #94a3b8;
+}
+
+.bodyMeta {
+  display: flex;
+  gap: 12px;
+  margin-top: 8px;
+  font-size: 0.82em;
+  color: #64748b;
+}
+[data-theme='dark'] .bodyMeta {
+  color: #94a3b8;
+}
+
+/* ===== Timeline Legend ===== */
+.timelineLegend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 16px;
+  font-size: 0.78em;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: #64748b;
+}
+[data-theme='dark'] .legendItem {
+  color: #94a3b8;
+}
+
+.legendDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* ===== Timeline ===== */
+.compactTimeline {
+  position: relative;
+  padding-left: 24px;
+}
+
+.timelineItem {
+  position: relative;
+  padding-bottom: 20px;
+  padding-left: 16px;
+  border-left: 2px solid #e2e8f0;
+}
+[data-theme='dark'] .timelineItem {
+  border-left-color: #334155;
+}
+
+.timelineItem:last-child {
+  border-left: 2px solid transparent;
+  padding-bottom: 0;
+}
+
+.timelineDot {
+  position: absolute;
+  left: -7px;
+  top: 4px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid white;
+}
+[data-theme='dark'] .timelineDot {
+  border-color: #1e293b;
+}
+
+.timelineYear {
+  font-size: 0.8em;
+  font-weight: 700;
+  color: #0e4d6b;
+  margin-bottom: 2px;
+}
+[data-theme='dark'] .timelineYear {
+  color: #7dd3fc;
+}
+
+.timelineEvent {
+  font-size: 0.9em;
+  color: #475569;
+}
+[data-theme='dark'] .timelineEvent {
+  color: #cbd5e1;
+}
+
+/* ===== Amendments Table ===== */
+.amendmentsTable {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 16px;
+  font-size: 0.88em;
+}
+
+.amendmentsTable th {
+  text-align: left;
+  padding: 10px 12px;
+  background: #f1f5f9;
+  border-bottom: 2px solid #e2e8f0;
+  font-weight: 600;
+  color: #475569;
+}
+[data-theme='dark'] .amendmentsTable th {
+  background: #0f172a;
+  border-bottom-color: #334155;
+  color: #94a3b8;
+}
+
+.amendmentsTable td {
+  padding: 10px 12px;
+  border-bottom: 1px solid #e2e8f0;
+  color: #475569;
+}
+[data-theme='dark'] .amendmentsTable td {
+  border-bottom-color: #334155;
+  color: #cbd5e1;
+}
+
+/* ===== Governance Tiers ===== */
+.tierCard {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  margin-bottom: 8px;
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+}
+[data-theme='dark'] .tierCard {
+  background: #1e293b;
+  border-color: #334155;
+}
+
+.tierLevel {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.78em;
+  font-weight: 700;
+  color: white;
+  flex-shrink: 0;
+}
+
+.tierName {
+  font-weight: 600;
+  font-size: 0.92em;
+  color: #0f172a;
+}
+[data-theme='dark'] .tierName {
+  color: #f1f5f9;
+}
+
+.tierStatus {
+  font-size: 0.78em;
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-weight: 500;
+}
+
+/* ===== Impact Badge ===== */
+.impactBadge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: 0.78em;
+  font-weight: 600;
+}
+
+.impactHigh {
+  background: #fee2e2;
+  color: #991b1b;
+}
+[data-theme='dark'] .impactHigh {
+  background: #450a0a;
+  color: #fca5a5;
+}
+
+.impactMedium {
+  background: #fef3c7;
+  color: #92400e;
+}
+[data-theme='dark'] .impactMedium {
+  background: #451a03;
+  color: #fcd34d;
+}
+
+.impactLow {
+  background: #dcfce7;
+  color: #166534;
+}
+[data-theme='dark'] .impactLow {
+  background: #052e16;
+  color: #86efac;
+}
+
+.impactUnknown {
+  background: #f1f5f9;
+  color: #64748b;
+}
+[data-theme='dark'] .impactUnknown {
+  background: #1e293b;
+  color: #94a3b8;
+}
+
+/* ===== Body Status Badges ===== */
+.bodyStatusActive {
+  background: #dcfce7;
+  color: #166534;
+}
+[data-theme='dark'] .bodyStatusActive {
+  background: #052e16;
+  color: #86efac;
+}
+
+.bodyStatusInactive {
+  background: #f1f5f9;
+  color: #64748b;
+}
+[data-theme='dark'] .bodyStatusInactive {
+  background: #1e293b;
+  color: #94a3b8;
+}
+
+/* ===== Empty State ===== */
+.emptyState {
+  text-align: center;
+  padding: 40px 20px;
+  color: #94a3b8;
+  font-size: 0.9em;
+}
+[data-theme='dark'] .emptyState {
+  color: #64748b;
+}
+
+/* ===== Section Title ===== */
+.sectionTitle {
+  font-size: 1.1em;
+  font-weight: 600;
+  color: #0f172a;
+  margin: 0 0 16px 0;
+}
+[data-theme='dark'] .sectionTitle {
+  color: #f1f5f9;
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 768px) {
+  .overviewGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .statCards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .heroTitle {
+    font-size: 1.2em;
+  }
+
+  .selectorBar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .actSelect {
+    min-width: 0;
+  }
+}

--- a/docs/src/components/ActAnatomyExplorer.tsx
+++ b/docs/src/components/ActAnatomyExplorer.tsx
@@ -1,0 +1,539 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import profiles from '../data/act-anatomy-profiles.json';
+import styles from './ActAnatomyExplorer.module.css';
+
+type TabKey = 'overview' | 'bodies' | 'timeline' | 'governance';
+
+interface Profile {
+  id: string;
+  title: string;
+  number: string;
+  year: number;
+  kind: { major: string; minor: string };
+  status: string;
+  domainCategory: string;
+  domainColor: string;
+  domainLabel: string;
+  pdfUrl: string;
+  summary: string;
+  repealedBy?: { actNumber: string; year: number; title: string };
+  functionalProfile: Record<string, number>;
+  statutoryBodies: {
+    name: string; sections: string;
+    currentStatus: string; operationalStatus: string;
+    maxMembers: number | null; powersCount: number;
+  }[];
+  amendments: { actNumber: string; year: number; impactRating: string; summary: string }[];
+  timeline: { year: number; event: string; type: string }[];
+  governanceHierarchy: { tiers: { level: number; name: string; status: string }[] };
+  dataConfidence: { legislativeFramework: string; historicalDetails: string; currentOperationalStatus: string };
+  crossReferences: { id: string; title: string }[];
+  stats: {
+    bodiesCount: number; activeBodiesCount: number;
+    amendmentsCount: number; timelineSpanYears: number;
+    totalPowers: number;
+  };
+}
+
+const TAB_LABELS: Record<TabKey, string> = {
+  overview: 'Overview',
+  bodies: 'Bodies',
+  timeline: 'Timeline',
+  governance: 'Governance',
+};
+
+const RADAR_LABELS: Record<string, string> = {
+  registration: 'Registration',
+  discipline: 'Discipline',
+  financial: 'Financial',
+  advisory: 'Advisory',
+  operational: 'Operational',
+  regulatory: 'Regulatory',
+};
+
+const CONFIDENCE_COLORS: Record<string, string> = {
+  high: '#22c55e',
+  medium: '#f59e0b',
+  low: '#ef4444',
+};
+
+const TIMELINE_COLORS: Record<string, string> = {
+  enactment: '#2563eb',
+  amendment: '#f59e0b',
+  establishment: '#22c55e',
+  predecessor: '#94a3b8',
+  development: '#8b5cf6',
+  governance: '#ec4899',
+  devolution: '#06b6d4',
+  repeal: '#ef4444',
+  related: '#64748b',
+  regulation: '#6366f1',
+};
+
+const IMPACT_CLASS: Record<string, string> = {
+  high: 'impactHigh',
+  medium: 'impactMedium',
+  low: 'impactLow',
+  unknown: 'impactUnknown',
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  'legally-active': '#22c55e',
+  active: '#22c55e',
+  obsolete: '#9e9e9e',
+  superseded: '#9e9e9e',
+  unknown: '#f59e0b',
+  repealed: '#ef4444',
+  regulated: '#64748b',
+  protected: '#8b5cf6',
+};
+
+// Group acts by domain for the <select> dropdown
+function groupByDomain(acts: Profile[]) {
+  const groups: Record<string, Profile[]> = {};
+  for (const act of acts) {
+    const key = act.domainLabel;
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(act);
+  }
+  return groups;
+}
+
+function RadarChartInner({ profile }: { profile: Profile }) {
+  const recharts = require('recharts');
+  const {
+    RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis,
+    Radar, ResponsiveContainer, Tooltip,
+  } = recharts;
+
+  const data = Object.entries(profile.functionalProfile).map(([key, value]) => ({
+    axis: RADAR_LABELS[key] || key,
+    value,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <RadarChart data={data} cx="50%" cy="50%" outerRadius="75%">
+        <PolarGrid stroke="var(--ifm-color-emphasis-300)" />
+        <PolarAngleAxis
+          dataKey="axis"
+          tick={{ fill: 'var(--ifm-font-color-base)', fontSize: 12 }}
+        />
+        <PolarRadiusAxis domain={[0, 5]} tickCount={6} tick={false} axisLine={false} />
+        <Radar
+          dataKey="value"
+          stroke={profile.domainColor}
+          fill={profile.domainColor}
+          fillOpacity={0.3}
+          strokeWidth={2}
+        />
+        <Tooltip
+          contentStyle={{
+            background: 'var(--ifm-background-color)',
+            border: '1px solid var(--ifm-color-emphasis-300)',
+            borderRadius: 8,
+            fontSize: '0.85em',
+          }}
+        />
+      </RadarChart>
+    </ResponsiveContainer>
+  );
+}
+
+function RadarChartWrapper({ profile }: { profile: Profile }) {
+  return (
+    <div className={styles.radarContainer}>
+      <h4 className={styles.sectionTitle}>Functional Profile</h4>
+      <BrowserOnly fallback={<div className={styles.radarPlaceholder}>Loading chart...</div>}>
+        {() => <RadarChartInner profile={profile} />}
+      </BrowserOnly>
+    </div>
+  );
+}
+
+function DataConfidencePanel({ confidence }: { confidence: Profile['dataConfidence'] }) {
+  const entries = [
+    { label: 'Legislative Framework', value: confidence.legislativeFramework },
+    { label: 'Historical Details', value: confidence.historicalDetails },
+    { label: 'Current Operations', value: confidence.currentOperationalStatus },
+  ];
+
+  return (
+    <div className={styles.confidencePanel}>
+      <h4 className={styles.confidenceTitle}>Data Confidence</h4>
+      {entries.map((e) => (
+        <div key={e.label} className={styles.confidenceRow}>
+          <span
+            className={styles.confidenceDot}
+            style={{ background: CONFIDENCE_COLORS[e.value] || '#94a3b8' }}
+          />
+          <span className={styles.confidenceLabel}>
+            {e.label}: <strong>{e.value}</strong>
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function CrossReferencesPanel({
+  refs,
+  onNavigate,
+}: {
+  refs: Profile['crossReferences'];
+  onNavigate: (id: string) => void;
+}) {
+  return (
+    <div className={styles.crossRefPanel}>
+      <h4 className={styles.crossRefTitle}>Cross-References</h4>
+      {refs.length === 0 ? (
+        <div className={styles.emptyState} style={{ padding: '12px 0' }}>
+          No cross-references to other acts in this ecosystem.
+        </div>
+      ) : (
+        <div className={styles.crossRefBadges}>
+          {refs.map((ref) => (
+            <button
+              key={ref.id}
+              className={styles.crossRefBadge}
+              onClick={() => onNavigate(ref.id)}
+              title={`Navigate to ${ref.title}`}
+            >
+              {ref.title}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function OverviewTab({
+  profile,
+  onNavigate,
+}: {
+  profile: Profile;
+  onNavigate: (id: string) => void;
+}) {
+  return (
+    <div className={styles.overviewGrid}>
+      <div className={styles.overviewLeft}>
+        <RadarChartWrapper profile={profile} />
+      </div>
+      <div className={styles.overviewRight}>
+        <DataConfidencePanel confidence={profile.dataConfidence} />
+        <CrossReferencesPanel refs={profile.crossReferences} onNavigate={onNavigate} />
+      </div>
+    </div>
+  );
+}
+
+function BodiesTab({ profile }: { profile: Profile }) {
+  if (profile.statutoryBodies.length === 0) {
+    return (
+      <div className={styles.emptyState}>
+        This act does not establish any statutory bodies.
+        Governance is exercised through existing government institutions.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div style={{ marginBottom: 12 }}>
+        <span className="badge badge--success" style={{ marginRight: 8 }}>
+          {profile.stats.activeBodiesCount} Active
+        </span>
+        <span className="badge badge--secondary">
+          {profile.stats.bodiesCount - profile.stats.activeBodiesCount} Obsolete/Unknown
+        </span>
+      </div>
+      {profile.statutoryBodies.map((body) => {
+        const isActive = body.currentStatus === 'legally-active';
+        const borderColor = isActive ? '#4CAF50' : '#9E9E9E';
+        return (
+          <div
+            key={body.name}
+            className={styles.bodyCard}
+            style={{ borderLeftColor: borderColor }}
+          >
+            <div className={styles.bodyHeader}>
+              <span className={styles.bodyName}>{body.name}</span>
+              <span
+                className={`${styles.tierStatus} ${isActive ? styles.bodyStatusActive : styles.bodyStatusInactive}`}
+              >
+                {body.currentStatus}
+              </span>
+              <span className={styles.bodySections}>{body.sections}</span>
+            </div>
+            <div className={styles.bodyMeta}>
+              {body.maxMembers != null && <span>Members: {body.maxMembers}</span>}
+              <span>Powers: {body.powersCount}</span>
+              <span>Operational: {body.operationalStatus}</span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function TimelineLegend() {
+  const items = [
+    { type: 'enactment', label: 'Enactment' },
+    { type: 'amendment', label: 'Amendment' },
+    { type: 'establishment', label: 'Establishment' },
+    { type: 'predecessor', label: 'Predecessor' },
+    { type: 'development', label: 'Development' },
+    { type: 'governance', label: 'Governance' },
+    { type: 'repeal', label: 'Repeal' },
+  ];
+  return (
+    <div className={styles.timelineLegend}>
+      {items.map((item) => (
+        <span key={item.type} className={styles.legendItem}>
+          <span
+            className={styles.legendDot}
+            style={{ background: TIMELINE_COLORS[item.type] }}
+          />
+          {item.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function TimelineTab({ profile }: { profile: Profile }) {
+  return (
+    <div>
+      <h4 className={styles.sectionTitle}>Key Events</h4>
+      <TimelineLegend />
+      <div className={styles.compactTimeline}>
+        {profile.timeline.map((item, i) => (
+          <div key={i} className={styles.timelineItem}>
+            <span
+              className={styles.timelineDot}
+              style={{ background: TIMELINE_COLORS[item.type] || '#94a3b8' }}
+            />
+            <div className={styles.timelineYear}>{item.year}</div>
+            <div className={styles.timelineEvent}>{item.event}</div>
+          </div>
+        ))}
+      </div>
+
+      {profile.amendments.length > 0 && (
+        <>
+          <h4 className={styles.sectionTitle} style={{ marginTop: 24 }}>Amendments</h4>
+          <table className={styles.amendmentsTable}>
+            <thead>
+              <tr>
+                <th>Act</th>
+                <th>Year</th>
+                <th>Impact</th>
+                <th>Summary</th>
+              </tr>
+            </thead>
+            <tbody>
+              {profile.amendments.map((a, i) => {
+                const impactCls = IMPACT_CLASS[a.impactRating] || IMPACT_CLASS.unknown;
+                return (
+                  <tr key={i}>
+                    <td>{a.actNumber}</td>
+                    <td>{a.year}</td>
+                    <td>
+                      <span
+                        className={`${styles.impactBadge} ${styles[impactCls]}`}
+                      >
+                        {a.impactRating}
+                      </span>
+                    </td>
+                    <td>{a.summary}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </>
+      )}
+
+      {profile.amendments.length === 0 && (
+        <div className={styles.emptyState} style={{ marginTop: 16 }}>
+          No amendments recorded for this act.
+        </div>
+      )}
+    </div>
+  );
+}
+
+function GovernanceTab({ profile }: { profile: Profile }) {
+  const tiers = profile.governanceHierarchy.tiers;
+
+  const levelColors = ['#2563eb', '#0891b2', '#059669', '#7c3aed', '#db2777', '#ea580c'];
+
+  return (
+    <div>
+      <h4 className={styles.sectionTitle}>Governance Hierarchy</h4>
+      {tiers.map((tier, i) => {
+        const color = levelColors[(tier.level - 1) % levelColors.length];
+        const statusColor = STATUS_COLORS[tier.status] || '#94a3b8';
+        return (
+          <div
+            key={i}
+            className={styles.tierCard}
+            style={{ marginLeft: (tier.level - 1) * 28 }}
+          >
+            <span className={styles.tierLevel} style={{ background: color }}>
+              L{tier.level}
+            </span>
+            <span className={styles.tierName}>{tier.name}</span>
+            <span
+              className={styles.tierStatus}
+              style={{
+                background: `${statusColor}20`,
+                color: statusColor,
+              }}
+            >
+              {tier.status}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function ActAnatomyExplorer() {
+  const typedProfiles = profiles as Profile[];
+  const [selectedActId, setSelectedActId] = useState(typedProfiles[0].id);
+  const [activeTab, setActiveTab] = useState<TabKey>('overview');
+
+  const selectedProfile = useMemo(
+    () => typedProfiles.find((p) => p.id === selectedActId) || typedProfiles[0],
+    [selectedActId],
+  );
+
+  // Reset tab when act changes
+  useEffect(() => {
+    setActiveTab('overview');
+  }, [selectedActId]);
+
+  // URL hash sync
+  useEffect(() => {
+    const hash = window.location.hash.slice(1);
+    if (hash) {
+      const found = typedProfiles.find((p) => p.id === hash);
+      if (found) setSelectedActId(found.id);
+    }
+  }, []);
+
+  useEffect(() => {
+    window.history.replaceState(null, '', `#${selectedActId}`);
+  }, [selectedActId]);
+
+  const grouped = useMemo(() => groupByDomain(typedProfiles), []);
+
+  const handleNavigate = (id: string) => {
+    const found = typedProfiles.find((p) => p.id === id);
+    if (found) setSelectedActId(found.id);
+  };
+
+  return (
+    <div className={styles.explorer}>
+      {/* Selector Bar */}
+      <div className={styles.selectorBar}>
+        <select
+          className={styles.actSelect}
+          value={selectedActId}
+          onChange={(e) => setSelectedActId(e.target.value)}
+        >
+          {Object.entries(grouped).map(([domain, acts]) => (
+            <optgroup key={domain} label={domain}>
+              {acts.map((act) => (
+                <option key={act.id} value={act.id}>
+                  {act.title} ({act.year}){act.status === 'repealed' ? ' [REPEALED]' : ''}
+                </option>
+              ))}
+            </optgroup>
+          ))}
+        </select>
+        <span
+          className={styles.domainBadge}
+          style={{ background: selectedProfile.domainColor }}
+        >
+          {selectedProfile.domainLabel}
+        </span>
+        <span className={styles.kindBadge}>
+          {selectedProfile.kind.minor}
+        </span>
+      </div>
+
+      {/* Hero Panel */}
+      <div className={styles.heroPanel}>
+        <h2 className={styles.heroTitle}>{selectedProfile.title}</h2>
+        <div className={styles.heroMeta}>
+          {selectedProfile.number} &middot; {selectedProfile.year} &middot;{' '}
+          {selectedProfile.status === 'repealed' ? 'Repealed' : 'Active'}
+        </div>
+
+        {selectedProfile.status === 'repealed' && selectedProfile.repealedBy && (
+          <div className={styles.repealedWarning}>
+            Repealed by {selectedProfile.repealedBy.title} ({selectedProfile.repealedBy.year})
+          </div>
+        )}
+
+        <div className={styles.statCards}>
+          <div className={styles.statCard}>
+            <div className={styles.statValue}>{selectedProfile.stats.bodiesCount}</div>
+            <div className={styles.statLabel}>Bodies</div>
+          </div>
+          <div className={styles.statCard}>
+            <div className={styles.statValue}>{selectedProfile.stats.amendmentsCount}</div>
+            <div className={styles.statLabel}>Amendments</div>
+          </div>
+          <div className={styles.statCard}>
+            <div className={styles.statValue}>{selectedProfile.stats.timelineSpanYears}</div>
+            <div className={styles.statLabel}>Years</div>
+          </div>
+          <div className={styles.statCard}>
+            <div className={styles.statValue}>{selectedProfile.stats.totalPowers}</div>
+            <div className={styles.statLabel}>Powers</div>
+          </div>
+        </div>
+
+        <p className={styles.heroSummary}>{selectedProfile.summary}</p>
+        <a
+          className={styles.pdfLink}
+          href={selectedProfile.pdfUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          View Source PDF &rarr;
+        </a>
+      </div>
+
+      {/* Tab Bar */}
+      <div className={styles.tabBar}>
+        {(Object.keys(TAB_LABELS) as TabKey[]).map((tab) => (
+          <button
+            key={tab}
+            className={`button button--sm ${
+              activeTab === tab ? 'button--primary' : 'button--outline button--secondary'
+            }`}
+            onClick={() => setActiveTab(tab)}
+          >
+            {TAB_LABELS[tab]}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab Content */}
+      {activeTab === 'overview' && (
+        <OverviewTab profile={selectedProfile} onNavigate={handleNavigate} />
+      )}
+      {activeTab === 'bodies' && <BodiesTab profile={selectedProfile} />}
+      {activeTab === 'timeline' && <TimelineTab profile={selectedProfile} />}
+      {activeTab === 'governance' && <GovernanceTab profile={selectedProfile} />}
+    </div>
+  );
+}

--- a/docs/src/data/act-anatomy-profiles.json
+++ b/docs/src/data/act-anatomy-profiles.json
@@ -1,0 +1,694 @@
+[
+  {
+    "id": "health-services-act-12-1952",
+    "title": "Health Services Act",
+    "number": "No. 12 of 1952",
+    "year": 1952,
+    "kind": { "major": "Legislation", "minor": "act" },
+    "status": "active",
+    "domainCategory": "health-admin",
+    "domainColor": "#2196F3",
+    "domainLabel": "Health Administration",
+    "pdfUrl": "https://www.srilankalaw.lk/h/454-health-services-act.html",
+    "summary": "Establishes Health Council, Regional Hospitals Boards, and Hospital Committees for governance of public health services.",
+    "functionalProfile": { "registration": 0, "discipline": 0, "financial": 0, "advisory": 4, "operational": 3, "regulatory": 0 },
+    "statutoryBodies": [
+      { "name": "Health Council", "sections": "Section 4", "currentStatus": "legally-active", "operationalStatus": "unknown", "maxMembers": 12, "powersCount": 2 },
+      { "name": "Regional Hospitals Board", "sections": "Sections 9-10, 16-20", "currentStatus": "obsolete", "operationalStatus": "superseded", "maxMembers": null, "powersCount": 2 },
+      { "name": "Hospital Committee", "sections": "Sections 11-15", "currentStatus": "obsolete", "operationalStatus": "superseded", "maxMembers": null, "powersCount": 2 }
+    ],
+    "amendments": [
+      { "actNumber": "No. 10 of 1956", "year": 1956, "impactRating": "low", "summary": "Renamed 'Director of Medical and Sanitary Services' to 'Director of Health Services'." },
+      { "actNumber": "No. 13 of 1962", "year": 1962, "impactRating": "medium", "summary": "Established 2-year terms for nominated Health Council members." },
+      { "actNumber": "No. 3 of 1977", "year": 1977, "impactRating": "low", "summary": "Updated constitutional reference to Article 150." },
+      { "actNumber": "No. 13 of 1987", "year": 1987, "impactRating": "medium", "summary": "Added Dentist to Health Council. Max members increased to 12." }
+    ],
+    "timeline": [
+      { "year": 1952, "event": "Health Services Act enacted", "type": "enactment" },
+      { "year": 1956, "event": "Amendment No. 10 — Title rename", "type": "amendment" },
+      { "year": 1962, "event": "Amendment No. 13 — Term limits", "type": "amendment" },
+      { "year": 1977, "event": "Amendment No. 3 — Constitutional ref", "type": "amendment" },
+      { "year": 1987, "event": "Amendment No. 13 — Added Dentist", "type": "amendment" },
+      { "year": 1989, "event": "Provincial Councils established", "type": "devolution" }
+    ],
+    "governanceHierarchy": {
+      "tiers": [
+        { "level": 1, "name": "Health Council", "status": "legally-active" },
+        { "level": 2, "name": "Regional Hospitals Board", "status": "obsolete" },
+        { "level": 3, "name": "Hospital Committee", "status": "obsolete" }
+      ]
+    },
+    "dataConfidence": { "legislativeFramework": "high", "historicalDetails": "medium", "currentOperationalStatus": "low" },
+    "crossReferences": [{ "id": "medical-ordinance-26-1927", "title": "Medical Ordinance" }],
+    "stats": { "bodiesCount": 3, "activeBodiesCount": 1, "amendmentsCount": 4, "timelineSpanYears": 37, "totalPowers": 6 }
+  },
+  {
+    "id": "medical-ordinance-26-1927",
+    "title": "Medical Ordinance",
+    "number": "No. 26 of 1927",
+    "year": 1927,
+    "kind": { "major": "Legislation", "minor": "ordinance" },
+    "status": "active",
+    "domainCategory": "medical-reg",
+    "domainColor": "#9C27B0",
+    "domainLabel": "Medical Regulation",
+    "pdfUrl": "http://www.au.slmc.gov.lk/wp-content/uploads/2023/02/Medical-Ordinance.pdf",
+    "summary": "Governs registration and regulation of medical practitioners, dentists, midwives, pharmacists, para-medical assistants, and nurses through the Sri Lanka Medical Council and College Council.",
+    "functionalProfile": { "registration": 5, "discipline": 5, "financial": 1, "advisory": 1, "operational": 1, "regulatory": 2 },
+    "statutoryBodies": [
+      { "name": "College Council", "sections": "Section 5", "currentStatus": "legally-active", "operationalStatus": "unknown", "maxMembers": 11, "powersCount": 5 },
+      { "name": "Sri Lanka Medical Council", "sections": "Sections 12-22A", "currentStatus": "legally-active", "operationalStatus": "active", "maxMembers": 25, "powersCount": 10 }
+    ],
+    "amendments": [
+      { "actNumber": "No. 23 of 1985", "year": 1985, "impactRating": "high", "summary": "Landmark: Added Part IIIA granting full regulatory powers." },
+      { "actNumber": "No. 30 of 1987", "year": 1987, "impactRating": "medium", "summary": "Restructured Council composition with elected categories." },
+      { "actNumber": "No. 25 of 1988", "year": 1988, "impactRating": "medium", "summary": "Further refined Council composition and election procedures." },
+      { "actNumber": "No. 15 of 1996", "year": 1996, "impactRating": "medium", "summary": "Modified registration provisions for medical practitioners." },
+      { "actNumber": "No. 33 of 1997", "year": 1997, "impactRating": "low", "summary": "Administrative and procedural amendments." },
+      { "actNumber": "No. 40 of 1998", "year": 1998, "impactRating": "high", "summary": "Significant governance and regulatory power changes." },
+      { "actNumber": "No. 6 of 2014", "year": 2014, "impactRating": "medium", "summary": "Updated regulatory authority and registration procedures." },
+      { "actNumber": "No. 1 of 2017", "year": 2017, "impactRating": "medium", "summary": "Modified Council composition and Part IIIA powers." },
+      { "actNumber": "No. 28 of 2018", "year": 2018, "impactRating": "medium", "summary": "Latest amendment updating Council structure and functions." }
+    ],
+    "timeline": [
+      { "year": 1927, "event": "Medical Ordinance enacted", "type": "enactment" },
+      { "year": 1985, "event": "Amendment No. 23 — Regulatory powers", "type": "amendment" },
+      { "year": 1987, "event": "Amendment No. 30 — Council restructured", "type": "amendment" },
+      { "year": 1988, "event": "Amendment No. 25 — Election refinement", "type": "amendment" },
+      { "year": 1996, "event": "Amendment No. 15 — Registration", "type": "amendment" },
+      { "year": 1997, "event": "Amendment No. 33 — Administrative", "type": "amendment" },
+      { "year": 1998, "event": "Amendment No. 40 — Governance", "type": "amendment" },
+      { "year": 2014, "event": "Amendment No. 6 — Updated powers", "type": "amendment" },
+      { "year": 2017, "event": "Amendment No. 1 — Composition", "type": "amendment" },
+      { "year": 2018, "event": "Amendment No. 28 — Latest update", "type": "amendment" }
+    ],
+    "governanceHierarchy": {
+      "tiers": [
+        { "level": 1, "name": "Sri Lanka Medical Council", "status": "legally-active" },
+        { "level": 2, "name": "College Council", "status": "legally-active" }
+      ]
+    },
+    "dataConfidence": { "legislativeFramework": "high", "historicalDetails": "medium", "currentOperationalStatus": "high" },
+    "crossReferences": [{ "id": "health-services-act-12-1952", "title": "Health Services Act" }],
+    "stats": { "bodiesCount": 2, "activeBodiesCount": 2, "amendmentsCount": 9, "timelineSpanYears": 91, "totalPowers": 15 }
+  },
+  {
+    "id": "medical-wants-ordinance-9-1912",
+    "title": "Medical Wants Ordinance",
+    "number": "No. 9 of 1912",
+    "year": 1912,
+    "kind": { "major": "Legislation", "minor": "ordinance" },
+    "status": "active",
+    "domainCategory": "health-admin",
+    "domainColor": "#2196F3",
+    "domainLabel": "Health Administration",
+    "pdfUrl": "https://employers.lk/wp-content/uploads/2021/03/5_Medical-Wants-Ordinance-No.9-of-1912.pdf",
+    "summary": "Consolidates the law relating to medical wants of labourers in planting districts. Establishes Medical Wants Committee, District Medical Officer system, and export duty-based funding for estate medical care.",
+    "functionalProfile": { "registration": 0, "discipline": 0, "financial": 4, "advisory": 2, "operational": 3, "regulatory": 0 },
+    "statutoryBodies": [
+      { "name": "Medical Wants Committee", "sections": "Sections 25-27", "currentStatus": "legally-active", "operationalStatus": "unknown", "maxMembers": null, "powersCount": 3 }
+    ],
+    "amendments": [
+      { "actNumber": "No. 46 of 1957", "year": 1957, "impactRating": "unknown", "summary": "Post-independence amendment." },
+      { "actNumber": "No. 35 of 1958", "year": 1958, "impactRating": "unknown", "summary": "Post-independence amendment." },
+      { "actNumber": "No. 33 of 1990", "year": 1990, "impactRating": "unknown", "summary": "Modern amendment — only one with accessible PDF." },
+      { "actNumber": "No. 53 of 1993", "year": 1993, "impactRating": "unknown", "summary": "Most recent amendment." }
+    ],
+    "timeline": [
+      { "year": 1912, "event": "Medical Wants Ordinance enacted", "type": "enactment" },
+      { "year": 1957, "event": "Amendment No. 46", "type": "amendment" },
+      { "year": 1958, "event": "Amendment No. 35", "type": "amendment" },
+      { "year": 1990, "event": "Amendment No. 33", "type": "amendment" },
+      { "year": 1993, "event": "Amendment No. 53 — Most recent", "type": "amendment" }
+    ],
+    "governanceHierarchy": {
+      "tiers": [
+        { "level": 1, "name": "Minister", "status": "legally-active" },
+        { "level": 2, "name": "Medical Wants Committee", "status": "legally-active" },
+        { "level": 3, "name": "District Medical Officers", "status": "legally-active" },
+        { "level": 4, "name": "Estate Superintendents", "status": "legally-active" }
+      ]
+    },
+    "dataConfidence": { "legislativeFramework": "medium", "historicalDetails": "low", "currentOperationalStatus": "low" },
+    "crossReferences": [],
+    "stats": { "bodiesCount": 1, "activeBodiesCount": 1, "amendmentsCount": 4, "timelineSpanYears": 81, "totalPowers": 3 }
+  },
+  {
+    "id": "mental-disease-ordinance-1-1873",
+    "title": "Mental Disease Ordinance",
+    "number": "No. 1 of 1873",
+    "year": 1873,
+    "kind": { "major": "Legislation", "minor": "ordinance" },
+    "status": "active",
+    "domainCategory": "health-admin",
+    "domainColor": "#2196F3",
+    "domainLabel": "Health Administration",
+    "pdfUrl": "https://www.commonlii.org/lk/legis/consol_act/md559196.pdf",
+    "summary": "Regulates the care, treatment, and custody of persons of unsound mind and administration of mental health institutions.",
+    "functionalProfile": { "registration": 0, "discipline": 0, "financial": 0, "advisory": 0, "operational": 5, "regulatory": 1 },
+    "statutoryBodies": [],
+    "amendments": [
+      { "actNumber": "No. 14 of 1952", "year": 1952, "impactRating": "unknown", "summary": "Post-independence amendment. Still titled 'Lunacy (Amendment)'." },
+      { "actNumber": "No. 27 of 1956", "year": 1956, "impactRating": "high", "summary": "Landmark: renamed from 'Lunacy' to 'Mental Diseases'. Last amendment — no changes in 69 years." }
+    ],
+    "timeline": [
+      { "year": 1873, "event": "Lunacy Ordinance enacted", "type": "enactment" },
+      { "year": 1952, "event": "Amendment No. 14", "type": "amendment" },
+      { "year": 1956, "event": "Renamed to Mental Diseases Ordinance", "type": "amendment" }
+    ],
+    "governanceHierarchy": {
+      "tiers": [
+        { "level": 1, "name": "Minister", "status": "legally-active" },
+        { "level": 2, "name": "Director of Mental Health", "status": "legally-active" },
+        { "level": 3, "name": "NIMH (Angoda)", "status": "legally-active" },
+        { "level": 4, "name": "District Courts", "status": "legally-active" }
+      ]
+    },
+    "dataConfidence": { "legislativeFramework": "high", "historicalDetails": "medium", "currentOperationalStatus": "medium" },
+    "crossReferences": [],
+    "stats": { "bodiesCount": 0, "activeBodiesCount": 0, "amendmentsCount": 2, "timelineSpanYears": 83, "totalPowers": 0 }
+  },
+  {
+    "id": "national-health-dev-fund-13-1981",
+    "title": "National Health Development Fund Act",
+    "number": "No. 13 of 1981",
+    "year": 1981,
+    "kind": { "major": "Legislation", "minor": "act" },
+    "status": "active",
+    "domainCategory": "health-admin",
+    "domainColor": "#2196F3",
+    "domainLabel": "Health Administration",
+    "pdfUrl": "https://www.lawnet.gov.lk/national-health-development-fund-3/",
+    "summary": "Establishes a fund and Board of Trustees for the development and improvement of health services in Sri Lanka.",
+    "functionalProfile": { "registration": 0, "discipline": 0, "financial": 5, "advisory": 1, "operational": 0, "regulatory": 0 },
+    "statutoryBodies": [
+      { "name": "Board of Trustees", "sections": "Section 3", "currentStatus": "legally-active", "operationalStatus": "unknown", "maxMembers": 7, "powersCount": 5 }
+    ],
+    "amendments": [
+      { "actNumber": "No. 17 of 1984", "year": 1984, "impactRating": "medium", "summary": "Granted borrowing power from banks, capped at aggregate fixed deposits." },
+      { "actNumber": "No. 26 of 1987", "year": 1987, "impactRating": "high", "summary": "Introduced auxiliary sub-funds with mandatory advisory committees." }
+    ],
+    "timeline": [
+      { "year": 1981, "event": "National Health Dev. Fund Act enacted", "type": "enactment" },
+      { "year": 1984, "event": "Amendment No. 17 — Borrowing power", "type": "amendment" },
+      { "year": 1987, "event": "Amendment No. 26 — Auxiliary funds", "type": "amendment" }
+    ],
+    "governanceHierarchy": {
+      "tiers": [
+        { "level": 1, "name": "Minister", "status": "legally-active" },
+        { "level": 2, "name": "Board of Trustees", "status": "legally-active" },
+        { "level": 3, "name": "Fund Operations", "status": "legally-active" },
+        { "level": 4, "name": "Auditor-General", "status": "legally-active" }
+      ]
+    },
+    "dataConfidence": { "legislativeFramework": "high", "historicalDetails": "medium", "currentOperationalStatus": "low" },
+    "crossReferences": [],
+    "stats": { "bodiesCount": 1, "activeBodiesCount": 1, "amendmentsCount": 2, "timelineSpanYears": 6, "totalPowers": 5 }
+  },
+  {
+    "id": "nursing-homes-reg-16-1949",
+    "title": "Nursing Homes (Regulations) Act",
+    "number": "No. 16 of 1949",
+    "year": 1949,
+    "kind": { "major": "Legislation", "minor": "act" },
+    "status": "active",
+    "domainCategory": "medical-reg",
+    "domainColor": "#9C27B0",
+    "domainLabel": "Medical Regulation",
+    "pdfUrl": "https://lankalaw.net/wp-content/uploads/2024/03/nh551326.pdf",
+    "summary": "Provides for registration and regulation of nursing homes to ensure standards of care and safety.",
+    "functionalProfile": { "registration": 4, "discipline": 2, "financial": 0, "advisory": 0, "operational": 0, "regulatory": 4 },
+    "statutoryBodies": [
+      { "name": "Nursing Homes Advisory Board", "sections": "Section 9", "currentStatus": "legally-active", "operationalStatus": "unknown", "maxMembers": 7, "powersCount": 3 }
+    ],
+    "amendments": [
+      { "actNumber": "No. 62 of 1988", "year": 1988, "impactRating": "medium", "summary": "Significantly increased registration and renewal fees." },
+      { "actNumber": "No. 63 of 1988", "year": 1988, "impactRating": "medium", "summary": "Redefined 'Director' to Director-General of Teaching Hospitals." }
+    ],
+    "timeline": [
+      { "year": 1949, "event": "Nursing Homes Act enacted", "type": "enactment" },
+      { "year": 1988, "event": "Amendments No. 62 & 63 — Fees + Director", "type": "amendment" }
+    ],
+    "governanceHierarchy": {
+      "tiers": [
+        { "level": 1, "name": "Minister", "status": "legally-active" },
+        { "level": 2, "name": "Director-General of Teaching Hospitals", "status": "legally-active" },
+        { "level": 3, "name": "Nursing Homes Advisory Board", "status": "legally-active" },
+        { "level": 4, "name": "Magistrate's Court", "status": "legally-active" }
+      ]
+    },
+    "dataConfidence": { "legislativeFramework": "high", "historicalDetails": "low", "currentOperationalStatus": "low" },
+    "crossReferences": [{ "id": "private-medical-inst-21-2006", "title": "Private Medical Institutions (Registration) Act" }],
+    "stats": { "bodiesCount": 1, "activeBodiesCount": 1, "amendmentsCount": 2, "timelineSpanYears": 39, "totalPowers": 3 }
+  },
+  {
+    "id": "poisons-opium-drugs-17-1929",
+    "title": "Poisons, Opium & Dangerous Drugs Ordinance",
+    "number": "No. 17 of 1929",
+    "year": 1929,
+    "kind": { "major": "Legislation", "minor": "ordinance" },
+    "status": "active",
+    "domainCategory": "food-drug",
+    "domainColor": "#FF9800",
+    "domainLabel": "Food & Drug Safety",
+    "pdfUrl": "https://www.nddcb.gov.lk/Docs/acts/25345.pdf",
+    "summary": "Controls the import, export, manufacture, sale, and possession of poisons, opium, and dangerous drugs.",
+    "functionalProfile": { "registration": 1, "discipline": 3, "financial": 0, "advisory": 0, "operational": 0, "regulatory": 5 },
+    "statutoryBodies": [],
+    "amendments": [
+      { "actNumber": "No. 13 of 1984", "year": 1984, "impactRating": "high", "summary": "Introduced death penalty for trafficking; set possession thresholds." },
+      { "actNumber": "No. 26 of 1986", "year": 1986, "impactRating": "medium", "summary": "Refined definitions; amended opium distribution authority." },
+      { "actNumber": "No. 41 of 2022", "year": 2022, "impactRating": "high", "summary": "Added methamphetamine; uniform 5g death penalty threshold." }
+    ],
+    "timeline": [
+      { "year": 1929, "event": "Poisons, Opium & Drugs Ordinance enacted", "type": "enactment" },
+      { "year": 1984, "event": "Amendment No. 13 — Death penalty", "type": "amendment" },
+      { "year": 1986, "event": "Amendment No. 26 — Opium reform", "type": "amendment" },
+      { "year": 2022, "event": "Amendment No. 41 — Methamphetamine", "type": "amendment" }
+    ],
+    "governanceHierarchy": {
+      "tiers": [
+        { "level": 1, "name": "Minister", "status": "legally-active" },
+        { "level": 2, "name": "Director (Regulatory Authority)", "status": "legally-active" },
+        { "level": 3, "name": "Provincial/District Boards", "status": "legally-active" },
+        { "level": 4, "name": "NDDCB", "status": "legally-active" }
+      ]
+    },
+    "dataConfidence": { "legislativeFramework": "high", "historicalDetails": "medium", "currentOperationalStatus": "low" },
+    "crossReferences": [{ "id": "nmra-act-5-2015", "title": "National Medicines Regulatory Authority Act" }],
+    "stats": { "bodiesCount": 0, "activeBodiesCount": 0, "amendmentsCount": 3, "timelineSpanYears": 93, "totalPowers": 0 }
+  },
+  {
+    "id": "private-medical-inst-21-2006",
+    "title": "Private Medical Institutions (Registration) Act",
+    "number": "No. 21 of 2006",
+    "year": 2006,
+    "kind": { "major": "Legislation", "minor": "act" },
+    "status": "active",
+    "domainCategory": "medical-reg",
+    "domainColor": "#9C27B0",
+    "domainLabel": "Medical Regulation",
+    "pdfUrl": "http://www.phsrc.lk/content/files/acts/ACT,No.21-2006_E.pdf",
+    "summary": "Requires registration of private medical institutions and establishes regulatory framework for private healthcare.",
+    "functionalProfile": { "registration": 5, "discipline": 2, "financial": 0, "advisory": 0, "operational": 0, "regulatory": 4 },
+    "statutoryBodies": [
+      { "name": "Private Health Services Regulatory Council (PHSRC)", "sections": "Sections 6-12", "currentStatus": "legally-active", "operationalStatus": "active", "maxMembers": 28, "powersCount": 11 }
+    ],
+    "amendments": [],
+    "timeline": [
+      { "year": 2006, "event": "Private Medical Institutions Act enacted", "type": "enactment" },
+      { "year": 2007, "event": "PHSRC constituted", "type": "establishment" }
+    ],
+    "governanceHierarchy": {
+      "tiers": [
+        { "level": 1, "name": "Minister", "status": "legally-active" },
+        { "level": 2, "name": "PHSRC", "status": "legally-active" },
+        { "level": 3, "name": "Provincial Directors of Health", "status": "legally-active" },
+        { "level": 4, "name": "Private Medical Institutions", "status": "regulated" }
+      ]
+    },
+    "dataConfidence": { "legislativeFramework": "high", "historicalDetails": "medium", "currentOperationalStatus": "medium" },
+    "crossReferences": [{ "id": "nursing-homes-reg-16-1949", "title": "Nursing Homes (Regulations) Act" }],
+    "stats": { "bodiesCount": 1, "activeBodiesCount": 1, "amendmentsCount": 0, "timelineSpanYears": 1, "totalPowers": 11 }
+  },
+  {
+    "id": "nurses-council-19-1988",
+    "title": "Sri Lanka Nurses' Council Act",
+    "number": "No. 19 of 1988",
+    "year": 1988,
+    "kind": { "major": "Legislation", "minor": "act" },
+    "status": "active",
+    "domainCategory": "medical-reg",
+    "domainColor": "#9C27B0",
+    "domainLabel": "Medical Regulation",
+    "pdfUrl": "http://www.lawnet.gov.lk/wp-content/uploads/Law%20Site/4-stats_1956_2006/set4/1988Y0V0C19A.html",
+    "summary": "Establishes the Sri Lanka Nurses' Council for registration, regulation, and standards of nursing practice.",
+    "functionalProfile": { "registration": 5, "discipline": 4, "financial": 2, "advisory": 1, "operational": 0, "regulatory": 2 },
+    "statutoryBodies": [
+      { "name": "Sri Lanka Nurses' Council", "sections": "Sections 2-13", "currentStatus": "legally-active", "operationalStatus": "active", "maxMembers": 17, "powersCount": 11 }
+    ],
+    "amendments": [],
+    "timeline": [
+      { "year": 1988, "event": "Nurses' Council Act enacted", "type": "enactment" },
+      { "year": 1988, "event": "Council constituted", "type": "establishment" }
+    ],
+    "governanceHierarchy": {
+      "tiers": [
+        { "level": 1, "name": "Minister", "status": "legally-active" },
+        { "level": 2, "name": "Sri Lanka Nurses' Council", "status": "legally-active" },
+        { "level": 3, "name": "Registrar", "status": "legally-active" },
+        { "level": 4, "name": "Registered Nurses", "status": "regulated" }
+      ]
+    },
+    "dataConfidence": { "legislativeFramework": "high", "historicalDetails": "medium", "currentOperationalStatus": "medium" },
+    "crossReferences": [
+      { "id": "medical-ordinance-26-1927", "title": "Medical Ordinance" },
+      { "id": "nursing-homes-reg-16-1949", "title": "Nursing Homes (Regulations) Act" }
+    ],
+    "stats": { "bodiesCount": 1, "activeBodiesCount": 1, "amendmentsCount": 0, "timelineSpanYears": 0, "totalPowers": 11 }
+  },
+  {
+    "id": "transplantation-tissues-48-1987",
+    "title": "Transplantation of Human Tissues Act",
+    "number": "No. 48 of 1987",
+    "year": 1987,
+    "kind": { "major": "Legislation", "minor": "act" },
+    "status": "active",
+    "domainCategory": "medical-reg",
+    "domainColor": "#9C27B0",
+    "domainLabel": "Medical Regulation",
+    "pdfUrl": "https://lankalaw.net/wp-content/uploads/2024/02/3423.pdf",
+    "summary": "Regulates the removal and transplantation of human tissues and organs, including consent and authorization.",
+    "functionalProfile": { "registration": 0, "discipline": 0, "financial": 0, "advisory": 4, "operational": 0, "regulatory": 3 },
+    "statutoryBodies": [
+      { "name": "Technical Advisory Council on Human Tissue Transplantation", "sections": "Sections 20-21", "currentStatus": "legally-active", "operationalStatus": "unknown", "maxMembers": null, "powersCount": 1 }
+    ],
+    "amendments": [],
+    "timeline": [
+      { "year": 1987, "event": "Transplantation of Human Tissues Act enacted", "type": "enactment" },
+      { "year": 1987, "event": "Technical Advisory Council constituted", "type": "establishment" }
+    ],
+    "governanceHierarchy": {
+      "tiers": [
+        { "level": 1, "name": "Minister", "status": "legally-active" },
+        { "level": 2, "name": "Director-General of Health Services", "status": "legally-active" },
+        { "level": 3, "name": "Technical Advisory Council", "status": "legally-active" },
+        { "level": 4, "name": "Medical Practitioners / Technicians", "status": "regulated" }
+      ]
+    },
+    "dataConfidence": { "legislativeFramework": "high", "historicalDetails": "medium", "currentOperationalStatus": "low" },
+    "crossReferences": [{ "id": "medical-ordinance-26-1927", "title": "Medical Ordinance" }],
+    "stats": { "bodiesCount": 1, "activeBodiesCount": 1, "amendmentsCount": 0, "timelineSpanYears": 0, "totalPowers": 1 }
+  },
+  {
+    "id": "food-act-26-1980",
+    "title": "Food Act",
+    "number": "No. 26 of 1980",
+    "year": 1980,
+    "kind": { "major": "Legislation", "minor": "act" },
+    "status": "active",
+    "domainCategory": "food-drug",
+    "domainColor": "#FF9800",
+    "domainLabel": "Food & Drug Safety",
+    "pdfUrl": "https://eohfs.health.gov.lk/food/images/pdf/acts/food_act_no26_1980_en.pdf",
+    "summary": "Provides for the regulation of the manufacture, import, sale, and distribution of food to ensure safety and standards.",
+    "functionalProfile": { "registration": 1, "discipline": 2, "financial": 0, "advisory": 4, "operational": 0, "regulatory": 5 },
+    "statutoryBodies": [
+      { "name": "Food Advisory Committee", "sections": "Sections 8-9", "currentStatus": "legally-active", "operationalStatus": "unknown", "maxMembers": 23, "powersCount": 1 }
+    ],
+    "amendments": [
+      { "actNumber": "No. 20 of 1991", "year": 1991, "impactRating": "high", "summary": "Comprehensive reform: changed licensing to registration, enhanced penalties, expanded prohibitions." },
+      { "actNumber": "No. 29 of 2011", "year": 2011, "impactRating": "high", "summary": "Restructured Food Advisory Committee to 23 members, quorum of 7." }
+    ],
+    "timeline": [
+      { "year": 1949, "event": "Food and Drugs Act (predecessor)", "type": "predecessor" },
+      { "year": 1980, "event": "Food Act enacted", "type": "enactment" },
+      { "year": 1991, "event": "Amendment No. 20 — Comprehensive reform", "type": "amendment" },
+      { "year": 2011, "event": "Amendment No. 29 — FAC restructured", "type": "amendment" }
+    ],
+    "governanceHierarchy": {
+      "tiers": [
+        { "level": 1, "name": "Minister", "status": "legally-active" },
+        { "level": 2, "name": "Food Advisory Committee", "status": "legally-active" },
+        { "level": 3, "name": "Chief Food Authority (DG Health)", "status": "legally-active" },
+        { "level": 4, "name": "Local Food Authorities", "status": "legally-active" },
+        { "level": 5, "name": "Authorised Officers", "status": "legally-active" }
+      ]
+    },
+    "dataConfidence": { "legislativeFramework": "high", "historicalDetails": "high", "currentOperationalStatus": "low" },
+    "crossReferences": [
+      { "id": "poisons-opium-drugs-17-1929", "title": "Poisons, Opium & Dangerous Drugs Ordinance" },
+      { "id": "nmra-act-5-2015", "title": "National Medicines Regulatory Authority Act" }
+    ],
+    "stats": { "bodiesCount": 1, "activeBodiesCount": 1, "amendmentsCount": 2, "timelineSpanYears": 31, "totalPowers": 1 }
+  },
+  {
+    "id": "sjgh-board-54-1983",
+    "title": "Sri Jayewardenepura General Hospital Board Act",
+    "number": "No. 54 of 1983",
+    "year": 1983,
+    "kind": { "major": "Legislation", "minor": "act" },
+    "status": "active",
+    "domainCategory": "hospital-mgmt",
+    "domainColor": "#4CAF50",
+    "domainLabel": "Hospital Management",
+    "pdfUrl": "https://www.srilankalaw.lk/YearWisePdf/1983/SRI%20JAYEWARDENEPURA%20GENERAL%20HOSPITAL%20BOARD%20ACT,%20NO.%2054%20OF%201983.pdf",
+    "summary": "Establishes a Board for the management and administration of Sri Jayewardenepura General Hospital.",
+    "functionalProfile": { "registration": 0, "discipline": 0, "financial": 3, "advisory": 0, "operational": 5, "regulatory": 0 },
+    "statutoryBodies": [
+      { "name": "SJGH Board", "sections": "Sections 2-7", "currentStatus": "legally-active", "operationalStatus": "active", "maxMembers": 11, "powersCount": 9 },
+      { "name": "Committee of Management", "sections": "Section 8", "currentStatus": "legally-active", "operationalStatus": "unknown", "maxMembers": 7, "powersCount": 1 }
+    ],
+    "amendments": [],
+    "timeline": [
+      { "year": 1983, "event": "SJGH Board Act enacted", "type": "enactment" },
+      { "year": 1984, "event": "Hospital operations begin", "type": "establishment" }
+    ],
+    "governanceHierarchy": {
+      "tiers": [
+        { "level": 1, "name": "Minister", "status": "legally-active" },
+        { "level": 2, "name": "SJGH Board", "status": "legally-active" },
+        { "level": 3, "name": "Committee of Management", "status": "legally-active" },
+        { "level": 4, "name": "Hospital Staff", "status": "regulated" }
+      ]
+    },
+    "dataConfidence": { "legislativeFramework": "high", "historicalDetails": "high", "currentOperationalStatus": "low" },
+    "crossReferences": [{ "id": "vk-memorial-hospital-38-1999", "title": "Vijaya Kumaratunga Memorial Hospital Board Act" }],
+    "stats": { "bodiesCount": 2, "activeBodiesCount": 2, "amendmentsCount": 0, "timelineSpanYears": 1, "totalPowers": 10 }
+  },
+  {
+    "id": "vk-memorial-hospital-38-1999",
+    "title": "Vijaya Kumaratunga Memorial Hospital Board Act",
+    "number": "No. 38 of 1999",
+    "year": 1999,
+    "kind": { "major": "Legislation", "minor": "act" },
+    "status": "active",
+    "domainCategory": "hospital-mgmt",
+    "domainColor": "#4CAF50",
+    "domainLabel": "Hospital Management",
+    "pdfUrl": "https://documents.gov.lk/view/acts/1999/11/38-1999_E.pdf",
+    "summary": "Establishes a 7-member Board for the management and administration of Vijaya Kumaratunga Memorial Hospital at Seeduwa.",
+    "functionalProfile": { "registration": 0, "discipline": 0, "financial": 3, "advisory": 0, "operational": 5, "regulatory": 0 },
+    "statutoryBodies": [
+      { "name": "VK Memorial Hospital Board", "sections": "Sections 2-9", "currentStatus": "legally-active", "operationalStatus": "active", "maxMembers": 7, "powersCount": 9 },
+      { "name": "Committee of Management", "sections": "Section 10", "currentStatus": "legally-active", "operationalStatus": "unknown", "maxMembers": null, "powersCount": 1 }
+    ],
+    "amendments": [],
+    "timeline": [
+      { "year": 1988, "event": "Vijaya Kumaratunga assassinated", "type": "predecessor" },
+      { "year": 1998, "event": "VK Memorial Foundation established", "type": "predecessor" },
+      { "year": 1999, "event": "Hospital Board Act enacted", "type": "enactment" },
+      { "year": 1999, "event": "Hospital opens at Seeduwa", "type": "establishment" },
+      { "year": 2024, "event": "Hospital celebrates 25th anniversary", "type": "development" }
+    ],
+    "governanceHierarchy": {
+      "tiers": [
+        { "level": 1, "name": "Minister", "status": "legally-active" },
+        { "level": 2, "name": "VK Memorial Hospital Board", "status": "legally-active" },
+        { "level": 3, "name": "Committee of Management", "status": "legally-active" },
+        { "level": 4, "name": "Hospital Staff", "status": "regulated" }
+      ]
+    },
+    "dataConfidence": { "legislativeFramework": "high", "historicalDetails": "high", "currentOperationalStatus": "medium" },
+    "crossReferences": [{ "id": "sjgh-board-54-1983", "title": "Sri Jayewardenepura General Hospital Board Act" }],
+    "stats": { "bodiesCount": 2, "activeBodiesCount": 2, "amendmentsCount": 0, "timelineSpanYears": 25, "totalPowers": 10 }
+  },
+  {
+    "id": "tobacco-alcohol-authority-27-2006",
+    "title": "National Authority on Tobacco and Alcohol Act",
+    "number": "No. 27 of 2006",
+    "year": 2006,
+    "kind": { "major": "Legislation", "minor": "act" },
+    "status": "active",
+    "domainCategory": "food-drug",
+    "domainColor": "#FF9800",
+    "domainLabel": "Food & Drug Safety",
+    "pdfUrl": "https://www.nddcb.gov.lk/Docs/acts/NATA%20Act%20English.pdf",
+    "summary": "Establishes NATA as a 14-member body corporate to combat tobacco and alcohol harm. First Asian country to ratify WHO FCTC.",
+    "functionalProfile": { "registration": 0, "discipline": 3, "financial": 2, "advisory": 2, "operational": 0, "regulatory": 5 },
+    "statutoryBodies": [
+      { "name": "National Authority on Tobacco and Alcohol (NATA)", "sections": "Sections 2-15", "currentStatus": "legally-active", "operationalStatus": "active", "maxMembers": 14, "powersCount": 12 }
+    ],
+    "amendments": [
+      { "actNumber": "No. 3 of 2015", "year": 2015, "impactRating": "high", "summary": "Mandated 80% pictorial health warnings on cigarette packaging." }
+    ],
+    "timeline": [
+      { "year": 2003, "event": "Sri Lanka ratifies WHO FCTC", "type": "predecessor" },
+      { "year": 2006, "event": "NATA Act enacted", "type": "enactment" },
+      { "year": 2015, "event": "Amendment — 80% pictorial warnings", "type": "amendment" },
+      { "year": 2016, "event": "E-cigarettes and flavoured cigarettes banned", "type": "governance" },
+      { "year": 2025, "event": "NATA at FCTC COP11 in Geneva", "type": "development" }
+    ],
+    "governanceHierarchy": {
+      "tiers": [
+        { "level": 1, "name": "Minister of Health", "status": "legally-active" },
+        { "level": 2, "name": "NATA", "status": "legally-active" },
+        { "level": 3, "name": "Authorized Officers", "status": "legally-active" },
+        { "level": 4, "name": "Staff of the Authority", "status": "regulated" }
+      ]
+    },
+    "dataConfidence": { "legislativeFramework": "high", "historicalDetails": "high", "currentOperationalStatus": "high" },
+    "crossReferences": [{ "id": "poisons-opium-drugs-17-1929", "title": "Poisons, Opium & Dangerous Drugs Ordinance" }],
+    "stats": { "bodiesCount": 1, "activeBodiesCount": 1, "amendmentsCount": 1, "timelineSpanYears": 19, "totalPowers": 12 }
+  },
+  {
+    "id": "suwaseriya-foundation-18-2018",
+    "title": "1990 Suwaseriya Foundation Act",
+    "number": "No. 18 of 2018",
+    "year": 2018,
+    "kind": { "major": "Legislation", "minor": "act" },
+    "status": "active",
+    "domainCategory": "emergency-services",
+    "domainColor": "#F44336",
+    "domainLabel": "Emergency Services",
+    "pdfUrl": "https://documents.gov.lk/view/acts/2018/7/18-2018_E.pdf",
+    "summary": "Establishes the 1990 Suwaseriya Foundation for free pre-hospital care ambulance services island-wide through 297+ ambulances.",
+    "functionalProfile": { "registration": 0, "discipline": 0, "financial": 3, "advisory": 0, "operational": 5, "regulatory": 0 },
+    "statutoryBodies": [
+      { "name": "1990 Suwaseriya Foundation", "sections": "Sections 2-25", "currentStatus": "legally-active", "operationalStatus": "active", "maxMembers": 7, "powersCount": 10 }
+    ],
+    "amendments": [],
+    "timeline": [
+      { "year": 2016, "event": "First ambulance launched in Hambantota", "type": "establishment" },
+      { "year": 2018, "event": "Suwaseriya Foundation Act enacted", "type": "enactment" },
+      { "year": 2019, "event": "Full island-wide coverage (297 ambulances)", "type": "development" },
+      { "year": 2020, "event": "COVID-19 frontline response", "type": "development" },
+      { "year": 2024, "event": "2 million patient milestone", "type": "development" }
+    ],
+    "governanceHierarchy": {
+      "tiers": [
+        { "level": 1, "name": "President of Sri Lanka", "status": "legally-active" },
+        { "level": 2, "name": "Minister of Health", "status": "legally-active" },
+        { "level": 3, "name": "Board of Management", "status": "legally-active" },
+        { "level": 4, "name": "Chief Executive Officer", "status": "legally-active" },
+        { "level": 5, "name": "Staff (EMTs, Pilots, Admin)", "status": "regulated" }
+      ]
+    },
+    "dataConfidence": { "legislativeFramework": "high", "historicalDetails": "high", "currentOperationalStatus": "high" },
+    "crossReferences": [],
+    "stats": { "bodiesCount": 1, "activeBodiesCount": 1, "amendmentsCount": 0, "timelineSpanYears": 8, "totalPowers": 10 }
+  },
+  {
+    "id": "nmra-act-5-2015",
+    "title": "National Medicines Regulatory Authority Act",
+    "number": "No. 5 of 2015",
+    "year": 2015,
+    "kind": { "major": "Legislation", "minor": "act" },
+    "status": "active",
+    "domainCategory": "food-drug",
+    "domainColor": "#FF9800",
+    "domainLabel": "Food & Drug Safety",
+    "pdfUrl": "https://www.lawnet.gov.lk/act-no-5-of-2015/",
+    "summary": "Establishes NMRA as a self-funded 13-member body corporate succeeding the CDDA. 147 sections in 7 Chapters. Regulates medicines, medical devices, borderline products, and cosmetics.",
+    "functionalProfile": { "registration": 4, "discipline": 3, "financial": 4, "advisory": 3, "operational": 0, "regulatory": 5 },
+    "statutoryBodies": [
+      { "name": "NMRA", "sections": "Sections 2-29", "currentStatus": "legally-active", "operationalStatus": "active", "maxMembers": 13, "powersCount": 15 },
+      { "name": "National Advisory Committee", "sections": "Sections 30-37", "currentStatus": "legally-active", "operationalStatus": "unknown", "maxMembers": null, "powersCount": 1 },
+      { "name": "Medicines Evaluation Committee (MEC)", "sections": "Sections 43-48", "currentStatus": "legally-active", "operationalStatus": "active", "maxMembers": null, "powersCount": 4 },
+      { "name": "Medical Devices Evaluation Committee (MDEC)", "sections": "Sections 68-73", "currentStatus": "legally-active", "operationalStatus": "active", "maxMembers": null, "powersCount": 4 },
+      { "name": "Borderline Products Evaluation Committee (BPEC)", "sections": "Sections 89-94", "currentStatus": "legally-active", "operationalStatus": "unknown", "maxMembers": null, "powersCount": 2 },
+      { "name": "Appeals Committee", "sections": "Section 123", "currentStatus": "legally-active", "operationalStatus": "unknown", "maxMembers": null, "powersCount": 1 }
+    ],
+    "amendments": [],
+    "timeline": [
+      { "year": 1971, "event": "Bibile Commission — National Drug Policy", "type": "predecessor" },
+      { "year": 1980, "event": "CDDA Act enacted (predecessor)", "type": "predecessor" },
+      { "year": 2015, "event": "NMRA Act enacted (147 sections)", "type": "enactment" },
+      { "year": 2017, "event": "NMRA achieves financial independence", "type": "development" },
+      { "year": 2023, "event": "Immunoglobulin scandal", "type": "governance" },
+      { "year": 2025, "event": "WHO integrity assessment hosted", "type": "development" },
+      { "year": 2025, "event": "Parliament approves pricing reform", "type": "governance" }
+    ],
+    "governanceHierarchy": {
+      "tiers": [
+        { "level": 1, "name": "Minister of Health", "status": "legally-active" },
+        { "level": 2, "name": "NMRA (13-member Board)", "status": "legally-active" },
+        { "level": 3, "name": "Evaluation Committees (MEC, MDEC, BPEC)", "status": "legally-active" },
+        { "level": 4, "name": "Chief Executive Officer", "status": "legally-active" },
+        { "level": 5, "name": "Regulatory Divisions and Staff", "status": "regulated" }
+      ]
+    },
+    "dataConfidence": { "legislativeFramework": "high", "historicalDetails": "high", "currentOperationalStatus": "high" },
+    "crossReferences": [{ "id": "poisons-opium-drugs-17-1929", "title": "Poisons, Opium & Dangerous Drugs Ordinance" }],
+    "stats": { "bodiesCount": 6, "activeBodiesCount": 6, "amendmentsCount": 0, "timelineSpanYears": 10, "totalPowers": 27 }
+  },
+  {
+    "id": "ayurveda-act-31-1961",
+    "title": "Ayurveda Act",
+    "number": "No. 31 of 1961",
+    "year": 1961,
+    "kind": { "major": "Legislation", "minor": "act" },
+    "status": "active",
+    "domainCategory": "traditional-med",
+    "domainColor": "#795548",
+    "domainLabel": "Traditional Medicine",
+    "pdfUrl": "https://www.parliament.lk/uploads/acts/gbills/english/3939.pdf",
+    "summary": "Establishes 3 statutory bodies for the development and regulation of 4 traditional medicine systems: Ayurveda, Siddha, Unani, and Desiya Chikitsa.",
+    "functionalProfile": { "registration": 5, "discipline": 4, "financial": 2, "advisory": 2, "operational": 3, "regulatory": 2 },
+    "statutoryBodies": [
+      { "name": "Department of Ayurveda", "sections": "Part I (S.2-9)", "currentStatus": "legally-active", "operationalStatus": "active", "maxMembers": null, "powersCount": 7 },
+      { "name": "Ayurveda Medical Council", "sections": "Part III (S.11-51)", "currentStatus": "legally-active", "operationalStatus": "active", "maxMembers": null, "powersCount": 7 },
+      { "name": "Ayurveda Education and Hospital Board", "sections": "Part IV", "currentStatus": "legally-active", "operationalStatus": "active", "maxMembers": null, "powersCount": 6 }
+    ],
+    "amendments": [
+      { "actNumber": "No. 9 of 1969", "year": 1969, "impactRating": "medium", "summary": "Financial auditing provisions for Ayurveda Medical Council funds." },
+      { "actNumber": "No. 7 of 1977", "year": 1977, "impactRating": "medium", "summary": "Restructured Board to align with University of Colombo." },
+      { "actNumber": "No. 19 of 2023", "year": 2023, "impactRating": "high", "summary": "Major modernization: Commissioner-General title, herbal garden registration, massage therapist registration." }
+    ],
+    "timeline": [
+      { "year": 1929, "event": "Ayurveda Vidyalaya established in Borella", "type": "predecessor" },
+      { "year": 1961, "event": "Ayurveda Act enacted", "type": "enactment" },
+      { "year": 1969, "event": "Amendment — Council fund auditing", "type": "amendment" },
+      { "year": 1977, "event": "Amendment — University alignment", "type": "amendment" },
+      { "year": 1979, "event": "Institute of Indigenous Medicine established", "type": "development" },
+      { "year": 2023, "event": "Amendment — Comprehensive modernization", "type": "amendment" }
+    ],
+    "governanceHierarchy": {
+      "tiers": [
+        { "level": 1, "name": "Minister of Health (or Indigenous Medicine)", "status": "legally-active" },
+        { "level": 2, "name": "Commissioner-General for Ayurveda", "status": "legally-active" },
+        { "level": 3, "name": "Department of Ayurveda", "status": "legally-active" },
+        { "level": 3, "name": "Ayurveda Medical Council", "status": "legally-active" },
+        { "level": 3, "name": "Ayurveda Education and Hospital Board", "status": "legally-active" }
+      ]
+    },
+    "dataConfidence": { "legislativeFramework": "medium", "historicalDetails": "medium", "currentOperationalStatus": "medium" },
+    "crossReferences": [{ "id": "homoeopathy-act-7-1970", "title": "Homoeopathy Act" }],
+    "stats": { "bodiesCount": 3, "activeBodiesCount": 3, "amendmentsCount": 3, "timelineSpanYears": 62, "totalPowers": 20 }
+  },
+  {
+    "id": "homoeopathy-act-7-1970",
+    "title": "Homoeopathy Act",
+    "number": "No. 7 of 1970",
+    "year": 1970,
+    "kind": { "major": "Legislation", "minor": "act" },
+    "status": "repealed",
+    "domainCategory": "traditional-med",
+    "domainColor": "#795548",
+    "domainLabel": "Traditional Medicine",
+    "pdfUrl": "https://lankalaw.net/wp-content/uploads/2025/02/1970Y0V0C7A.html",
+    "summary": "Established the Homoeopathic Council for registration and regulation of homoeopathic practitioners. Repealed by Act No. 10 of 2016.",
+    "repealedBy": { "actNumber": "No. 10 of 2016", "year": 2016, "title": "Homoeopathy Act, No. 10 of 2016" },
+    "functionalProfile": { "registration": 5, "discipline": 4, "financial": 3, "advisory": 0, "operational": 0, "regulatory": 1 },
+    "statutoryBodies": [
+      { "name": "Homoeopathic Council", "sections": "S.2-26", "currentStatus": "obsolete", "operationalStatus": "superseded", "maxMembers": null, "powersCount": 7 }
+    ],
+    "amendments": [],
+    "timeline": [
+      { "year": 1961, "event": "Ayurveda Act enacted (parallel framework)", "type": "predecessor" },
+      { "year": 1970, "event": "Homoeopathy Act enacted", "type": "enactment" },
+      { "year": 2000, "event": "Council governance difficulties reported", "type": "development" },
+      { "year": 2016, "event": "Repealed by Homoeopathy Act No. 10 of 2016", "type": "repeal" }
+    ],
+    "governanceHierarchy": {
+      "tiers": [
+        { "level": 1, "name": "Minister of Health", "status": "repealed" },
+        { "level": 2, "name": "Homoeopathic Council", "status": "repealed" },
+        { "level": 3, "name": "Homoeopathic Fund", "status": "repealed" }
+      ]
+    },
+    "dataConfidence": { "legislativeFramework": "medium", "historicalDetails": "low", "currentOperationalStatus": "high" },
+    "crossReferences": [{ "id": "ayurveda-act-31-1961", "title": "Ayurveda Act" }],
+    "stats": { "bodiesCount": 1, "activeBodiesCount": 0, "amendmentsCount": 0, "timelineSpanYears": 46, "totalPowers": 7 }
+  }
+]


### PR DESCRIPTION
Interactive single-act anatomy dashboard for 18 Ministry of Health acts. Includes act selector, hero panel with stats, radar chart (Recharts), statutory bodies tab, amendment timeline, governance hierarchy, data confidence indicators, and cross-reference navigation. Full dark mode and responsive layout support.